### PR TITLE
BE-7, fix: cicd build fail

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -6,4 +6,4 @@ reviewers:
   - jryouda
   - sonjh919
 
-numberOfReviewers: 2
+numberOfReviewers: 0

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,12 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-          java-version: 1.17
+          distribution: 'corretto'
+          java-version: '17'
 
     - name: Grant execute permission for gradlew
       working-directory: ./app


### PR DESCRIPTION
# 설명

Action 빌드 하면서 아래 에러 발생.
```
Run actions/setup-java@v2
  with:
    java-version: 1.17
    java-package: jdk
    architecture: x6[4](https://github.com/open-run/backend/actions/runs/7475598311/job/20344069423#step:3:4)
    check-latest: false
    server-id: github
    server-username: GITHUB_ACTOR
    server-password: GITHUB_TOKEN
    overwrite-settings: true
    job-status: success
Error: Input required and not supplied: distribution
```

연관된 이슈: BE-7

## 변경사항

{{replace this}}

### 변경의 종류 (여러 가지 선택 가능)

- [x] 버그 수정

# 체크리스트

- [ ] 테스트를 통과했나요?
- [ ] 컴파일 가능한가요?
- [ ] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요?
- [ ] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [ ] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?
