### PR TITLE
BE-50, refactor: separate authorization & userBung related logics

### DIFF
--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,8 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/bungs")
 @RequiredArgsConstructor
 public class BungController {
-
-
     private final BungService bungService;
 
     @PostMapping()
@@ -80,33 +77,4 @@ public class BungController {
             .message("success")
             .build());
     }
-
-    @PatchMapping("/{bungId}/change-owner")
-    @Operation(summary = "벙주 변경(벙주만 가능)")
-    public ResponseEntity<Response<Void>> changeOwner(
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PathVariable String bungId,
-        @RequestParam String newOwnerUserId
-    ) {
-        bungService.changeOwner(userDetails, bungId, newOwnerUserId);
-        return ResponseEntity.ok().body(Response.<Void>builder()
-            .message("Owner changed successfully")
-            .build());
-    }
-
-    @DeleteMapping("/{bungId}/members/{userIdToRemove}")
-    @Operation(summary = "멤버 삭제하기(벙주만 가능)")
-    public ResponseEntity<Response<Void>> kickMember(
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PathVariable String bungId,
-        @PathVariable String userIdToRemove
-    ) {
-        bungService.removeUserFromBung(userDetails, bungId, userIdToRemove);
-        // TODO: Delete endpoint들의 response status accepted -> ok로 변경하기
-        return ResponseEntity.accepted().body(Response.<Void>builder()
-            .message("success")
-            .build());
-    }
-
-
 }

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -47,25 +47,4 @@ public class BungService {
     public void deleteBung(UserDetailsImpl userDetails, String bungId) {
         bungRepository.deleteByBungId(bungId);
     }
-
-    @Transactional
-    @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
-    public void changeOwner(UserDetailsImpl userDetails, String bungId, String newOwnerUserId) {
-        UserBung currentOwner = userBungRepository.findCurrentOwner(bungId);
-
-        currentOwner.disableOwnerBung();
-        userBungRepository.save(currentOwner);
-
-        UserBung newOwner = userBungRepository.findByUserIdAndBungId(newOwnerUserId, bungId);
-        newOwner.enableOwnerBung();
-        userBungRepository.save(newOwner);
-    }
-
-    @Transactional
-    @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
-    public void removeUserFromBung(UserDetailsImpl userDetails, String bungId,
-        String userIdToRemove) {
-        UserBung userBung = userBungRepository.findByUserIdAndBungId(userIdToRemove, bungId);
-        userBungRepository.removeUserFromBung(userBung);
-    }
 }

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -43,21 +43,13 @@ public class BungService {
         return new BungDetailDto(bungRepository.findByBungId(bungId));
     }
 
-    // TODO: separate authentication logic
-    public boolean isOwnerOfBung(@AuthenticationPrincipal UserDetailsImpl userDetails,
-        String bungId) {
-        UserBung userBung = userBungRepository.findByUserIdAndBungId(
-            userDetails.getUser().getUserId(), bungId);
-        return userBung.isOwner();
-    }
-
-    @PreAuthorize("@bungService.isOwnerOfBung(#userDetails, #bungId)")
+    @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
     public void deleteBung(UserDetailsImpl userDetails, String bungId) {
         bungRepository.deleteByBungId(bungId);
     }
 
     @Transactional
-    @PreAuthorize("@bungService.isOwnerOfBung(#userDetails, #bungId)")
+    @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
     public void changeOwner(UserDetailsImpl userDetails, String bungId, String newOwnerUserId) {
         UserBung currentOwner = userBungRepository.findCurrentOwner(bungId);
 
@@ -70,7 +62,7 @@ public class BungService {
     }
 
     @Transactional
-    @PreAuthorize("@bungService.isOwnerOfBung(#userDetails, #bungId)")
+    @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
     public void removeUserFromBung(UserDetailsImpl userDetails, String bungId,
         String userIdToRemove) {
         UserBung userBung = userBungRepository.findByUserIdAndBungId(userIdToRemove, bungId);

--- a/src/main/java/io/openur/domain/userbung/controller/UserBungController.java
+++ b/src/main/java/io/openur/domain/userbung/controller/UserBungController.java
@@ -1,5 +1,50 @@
 package io.openur.domain.userbung.controller;
 
+import io.openur.domain.userbung.service.UserBungService;
+import io.openur.global.common.Response;
+import io.openur.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/bungs")
+@RequiredArgsConstructor
 public class UserBungController {
 
+	private final UserBungService userBungService;
+
+	@PatchMapping("/{bungId}/change-owner")
+	@Operation(summary = "벙주 변경(벙주만 가능)")
+	public ResponseEntity<Response<Void>> changeOwner(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable String bungId,
+		@RequestParam String newOwnerUserId
+	) {
+		userBungService.changeOwner(userDetails, bungId, newOwnerUserId);
+		return ResponseEntity.ok().body(Response.<Void>builder()
+			.message("Owner changed successfully")
+			.build());
+	}
+
+	@DeleteMapping("/{bungId}/members/{userIdToRemove}")
+	@Operation(summary = "멤버 삭제하기(벙주만 가능)")
+	public ResponseEntity<Response<Void>> kickMember(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@PathVariable String bungId,
+		@PathVariable String userIdToRemove
+	) {
+		userBungService.removeUserFromBung(userDetails, bungId, userIdToRemove);
+		// TODO: Delete endpoint들의 response status accepted -> ok로 변경하기
+		return ResponseEntity.accepted().body(Response.<Void>builder()
+			.message("success")
+			.build());
+	}
 }

--- a/src/main/java/io/openur/domain/userbung/service/UserBungService.java
+++ b/src/main/java/io/openur/domain/userbung/service/UserBungService.java
@@ -1,5 +1,10 @@
 package io.openur.domain.userbung.service;
+
+import io.openur.domain.userbung.model.UserBung;
+import io.openur.domain.userbung.repository.UserBungRepositoryImpl;
+import io.openur.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,4 +13,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserBungService {
 
+	private final UserBungRepositoryImpl userBungRepository;
+
+	@Transactional
+	@PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
+	public void changeOwner(UserDetailsImpl userDetails, String bungId, String newOwnerUserId) {
+		UserBung currentOwner = userBungRepository.findCurrentOwner(bungId);
+
+		currentOwner.disableOwnerBung();
+		userBungRepository.save(currentOwner);
+
+		UserBung newOwner = userBungRepository.findByUserIdAndBungId(newOwnerUserId, bungId);
+		newOwner.enableOwnerBung();
+		userBungRepository.save(newOwner);
+	}
+
+	@Transactional
+	@PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
+	public void removeUserFromBung(UserDetailsImpl userDetails, String bungId,
+		String userIdToRemove) {
+		UserBung userBung = userBungRepository.findByUserIdAndBungId(userIdToRemove, bungId);
+		userBungRepository.removeUserFromBung(userBung);
+	}
 }

--- a/src/main/java/io/openur/global/security/MethodSecurityService.java
+++ b/src/main/java/io/openur/global/security/MethodSecurityService.java
@@ -1,0 +1,23 @@
+package io.openur.global.security;
+
+import io.openur.domain.userbung.model.UserBung;
+import io.openur.domain.userbung.repository.UserBungRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MethodSecurityService {
+
+	private final UserBungRepositoryImpl userBungRepository;
+
+	public boolean isOwnerOfBung(@AuthenticationPrincipal UserDetailsImpl userDetails,
+		String bungId) {
+		UserBung userBung = userBungRepository.findByUserIdAndBungId(
+			userDetails.getUser().getUserId(), bungId);
+		return userBung.isOwner();
+	}
+}

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -1,16 +1,12 @@
 package io.openur.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openur.config.TestSupport;
-import io.openur.domain.userbung.entity.UserBungEntity;
 import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,24 +41,6 @@ public class BungApiTest extends TestSupport {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonify(submittedBung))
         ).andExpect(status().isCreated());
-    }
-
-    @Test
-    @DisplayName("회원 제거")
-    void kickMember_successTest() throws Exception {
-        String token = getTestUserToken("test1@test.com");
-        String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-        String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
-
-        mockMvc.perform(
-            delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
-                .header(AUTH_HEADER, token)
-                .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isAccepted());
-
-        Optional<UserBungEntity> kickedUserBung = userBungJpaRepository
-            .findByUserEntity_UserIdAndBungEntity_BungId(userIdToKick, bungId);
-        assertThat(kickedUserBung).isEmpty();
     }
 
     @Nested
@@ -127,98 +105,4 @@ public class BungApiTest extends TestSupport {
 
     }
 
-    @Nested
-    @DisplayName("벙주 변경")
-    class changeOwnerTest {
-        @Test
-        @DisplayName("200 Ok.")
-        @Transactional
-        void changeOwner_isOkTest() throws Exception {
-            String token = getTestUserToken("test1@test.com");
-
-            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-            String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
-            String oldOwnerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
-
-            mockMvc.perform(
-                patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId, newOwnerUserId)
-                    .header(AUTH_HEADER, token)
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andExpect(status().isOk());
-
-            Optional<UserBungEntity> newOwnerBung = userBungJpaRepository
-                .findByUserEntity_UserIdAndBungEntity_BungId(newOwnerUserId, bungId);
-            assertThat(newOwnerBung).isPresent();
-            assertThat(newOwnerBung.get().isOwner()).isTrue();
-
-            Optional<UserBungEntity> oldOwnerBung = userBungJpaRepository
-                .findByUserEntity_UserIdAndBungEntity_BungId(oldOwnerUserId, bungId);
-            assertThat(oldOwnerBung).isPresent();
-            assertThat(oldOwnerBung.get().isOwner()).isFalse();
-        }
-
-        @Test
-        @DisplayName("403 Forbidden. Authorization Header 없음")
-        @Transactional
-        void changeOwner_isForbidden() throws Exception {
-            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-            String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
-
-            mockMvc.perform(
-                patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId, newOwnerUserId)
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andExpect(status().isForbidden());
-        }
-
-        @Test
-        @DisplayName("403 Forbidden. Bung owner 가 아닌 경우")
-        @Transactional
-        void changeOwner_isForbidden_notOwner() throws Exception {
-            String notOwnerToken = getTestUserToken("test2@test.com");
-
-            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-            String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
-
-            mockMvc.perform(
-                patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
-                    newOwnerUserId)
-                    .header(AUTH_HEADER, notOwnerToken)
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andExpect(status().isForbidden());
-        }
-
-        @Test
-        @DisplayName("401 Unauthorized. invalid Authorization Header")
-        @Transactional
-        void changeOwner_isUnauthorized() throws Exception {
-            String invalidToken = "Bearer invalidToken";
-
-            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-            String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
-
-            mockMvc.perform(
-                patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
-                    newOwnerUserId)
-                    .header(AUTH_HEADER, invalidToken)
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andExpect(status().isUnauthorized());
-        }
-
-        @Test
-        @DisplayName("401 Unauthorized. Unknown user token")
-        @Transactional
-        void deleteBung_isUnauthorized_unknownUser() throws Exception {
-            String unknownUserToken = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ5ZWppbmtlbGx5am9vQGdtYWlsLmNvbSIsImV4cCI6MTcyMzYyNDgxMCwiaWF0IjoxNzIzNjIxMjEwfQ.wH-eJCvEBgFg_QjWr7CdxBpMqlQzGt45DLmrsWju-HU";
-
-            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-            String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
-
-            mockMvc.perform(
-                patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
-                    newOwnerUserId)
-                    .header(AUTH_HEADER, unknownUserToken)
-                    .contentType(MediaType.APPLICATION_JSON)
-            ).andExpect(status().isUnauthorized());
-        }
-    }
 }

--- a/src/test/java/io/openur/controller/UserBungApiTest.java
+++ b/src/test/java/io/openur/controller/UserBungApiTest.java
@@ -1,6 +1,137 @@
 package io.openur.controller;
 
-import io.openur.config.TestSupport;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.openur.config.TestSupport;
+import io.openur.domain.userbung.entity.UserBungEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
 public class UserBungApiTest extends TestSupport {
+
+	private static final String PREFIX = "/v1/bungs";
+
+	@Test
+	@DisplayName("멤버 제거")
+	void kickMember_successTest() throws Exception {
+		String token = getTestUserToken("test1@test.com");
+		String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+		String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+		mockMvc.perform(
+			delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
+				.header(AUTH_HEADER, token)
+				.contentType(MediaType.APPLICATION_JSON)
+		).andExpect(status().isAccepted());
+
+		Optional<UserBungEntity> kickedUserBung = userBungJpaRepository
+			.findByUserEntity_UserIdAndBungEntity_BungId(userIdToKick, bungId);
+		assertThat(kickedUserBung).isEmpty();
+	}
+
+	@Nested
+	@DisplayName("벙주 변경")
+	class changeOwnerTest {
+
+		@Test
+		@DisplayName("200 Ok.")
+		@Transactional
+		void changeOwner_isOkTest() throws Exception {
+			String token = getTestUserToken("test1@test.com");
+
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+			String oldOwnerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+
+			mockMvc.perform(
+				patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
+					newOwnerUserId)
+					.header(AUTH_HEADER, token)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk());
+
+			Optional<UserBungEntity> newOwnerBung = userBungJpaRepository
+				.findByUserEntity_UserIdAndBungEntity_BungId(newOwnerUserId, bungId);
+			assertThat(newOwnerBung).isPresent();
+			assertThat(newOwnerBung.get().isOwner()).isTrue();
+
+			Optional<UserBungEntity> oldOwnerBung = userBungJpaRepository
+				.findByUserEntity_UserIdAndBungEntity_BungId(oldOwnerUserId, bungId);
+			assertThat(oldOwnerBung).isPresent();
+			assertThat(oldOwnerBung.get().isOwner()).isFalse();
+		}
+
+		@Test
+		@DisplayName("403 Forbidden. Authorization Header 없음")
+		@Transactional
+		void changeOwner_isForbidden() throws Exception {
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			mockMvc.perform(
+				patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
+					newOwnerUserId)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("403 Forbidden. Bung owner 가 아닌 경우")
+		@Transactional
+		void changeOwner_isForbidden_notOwner() throws Exception {
+			String notOwnerToken = getTestUserToken("test2@test.com");
+
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			mockMvc.perform(
+				patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
+					newOwnerUserId)
+					.header(AUTH_HEADER, notOwnerToken)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isForbidden());
+		}
+
+		@Test
+		@DisplayName("401 Unauthorized. invalid Authorization Header")
+		@Transactional
+		void changeOwner_isUnauthorized() throws Exception {
+			String invalidToken = "Bearer invalidToken";
+
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			mockMvc.perform(
+				patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
+					newOwnerUserId)
+					.header(AUTH_HEADER, invalidToken)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isUnauthorized());
+		}
+
+		@Test
+		@DisplayName("401 Unauthorized. Unknown user token")
+		@Transactional
+		void changeOwner_isUnauthorized_unknownUser() throws Exception {
+			String unknownUserToken = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ5ZWppbmtlbGx5am9vQGdtYWlsLmNvbSIsImV4cCI6MTcyMzYyNDgxMCwiaWF0IjoxNzIzNjIxMjEwfQ.wH-eJCvEBgFg_QjWr7CdxBpMqlQzGt45DLmrsWju-HU";
+
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String newOwnerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			mockMvc.perform(
+				patch(PREFIX + "/{bungId}/change-owner?newOwnerUserId={newOwnerUserId}", bungId,
+					newOwnerUserId)
+					.header(AUTH_HEADER, unknownUserToken)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isUnauthorized());
+		}
+	}
 }


### PR DESCRIPTION
# 설명

userBung 분리 작업만 하려고 했는데 해보니 isOwnerOfBung 메소드를 두개의 서비스에서 사용하게 되길래 얘 분리도 같이 해벌임.

연관된 이슈: [BE-50](https://open-run.atlassian.net/browse/BE-50)

## 변경사항

커밋 순 확인

### 변경의 종류 (여러 가지 선택 가능)

- [x] 기타 : 리팩토링

# Author 체크리스트

- [x] 테스트를 통과했나요?
- [x] 컴파일 가능한가요?
- [x] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [x] 바뀐 부분에 대해 문서화도 새로 하셨나요?
- [x] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [x] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?


[BE-50]: https://open-run.atlassian.net/browse/BE-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ