### PR TITLE
BE-55: `/v1/bungs/hashtags` 추가

### DIFF
--- a/src/main/java/io/openur/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/io/openur/domain/hashtag/controller/HashtagController.java
@@ -1,0 +1,32 @@
+package io.openur.domain.hashtag.controller;
+
+import io.openur.domain.hashtag.service.HashtagService;
+import io.openur.global.common.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/bungs")
+@RequiredArgsConstructor
+public class HashtagController {
+
+	private final HashtagService hashtagService;
+
+	@GetMapping("/hashtags")
+	@Operation(summary = "입력받은 문자열이 포함된 기존 해시태그 리스트 불러오기")
+	public ResponseEntity<Response<List<String>>> getHashtags(
+		@RequestParam String tag
+	) {
+		List<String> hashtags = hashtagService.getHashtagList(tag);
+		return ResponseEntity.ok().body(Response.<List<String>>builder()
+			.message("success")
+			.data(hashtags)
+			.build());
+	}
+}

--- a/src/main/java/io/openur/domain/hashtag/repository/HashtagJpaRepository.java
+++ b/src/main/java/io/openur/domain/hashtag/repository/HashtagJpaRepository.java
@@ -11,4 +11,6 @@ public interface HashtagJpaRepository extends JpaRepository<HashtagEntity, Long>
     List<HashtagEntity> findByHashtagStrIn(List<String> hashtagStrs);
 
     List<HashtagEntity> findByHashtagIdIn(List<Long> hashtagIds);
+
+    List<HashtagEntity> findByHashtagStrContaining(String substring);
 }

--- a/src/main/java/io/openur/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/io/openur/domain/hashtag/repository/HashtagRepository.java
@@ -1,7 +1,6 @@
 package io.openur.domain.hashtag.repository;
 
 import io.openur.domain.hashtag.model.Hashtag;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +12,6 @@ public interface HashtagRepository {
     List<Hashtag> findByHashtagStrIn(List<String> hashtagStrs);
 
     List<Hashtag> findByHashtagIdIn(List<Long> hashtagIds);
+
+    List<Hashtag> findByHashtagStrContaining(String substring);
 }

--- a/src/main/java/io/openur/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -54,4 +54,12 @@ public class HashtagRepositoryImpl implements HashtagRepository {
             .map(Hashtag::from)
             .toList();
     }
+
+    @Override
+    public List<Hashtag> findByHashtagStrContaining(String substring) {
+        return hashtagJpaRepository.findByHashtagStrContaining(substring)
+            .stream()
+            .map(Hashtag::from)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/io/openur/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -60,6 +60,6 @@ public class HashtagRepositoryImpl implements HashtagRepository {
         return hashtagJpaRepository.findByHashtagStrContaining(substring)
             .stream()
             .map(Hashtag::from)
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/src/main/java/io/openur/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/io/openur/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,23 @@
+package io.openur.domain.hashtag.service;
+
+import io.openur.domain.hashtag.model.Hashtag;
+import io.openur.domain.hashtag.repository.HashtagRepositoryImpl;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagService {
+
+	private final HashtagRepositoryImpl hashtagRepository;
+
+	public List<String> getHashtagList(String substring) {
+		return hashtagRepository.findByHashtagStrContaining(substring)
+			.stream()
+			.map(Hashtag::getHashtagStr)
+			.toList();
+	}
+}

--- a/src/main/java/io/openur/global/common/Response.java
+++ b/src/main/java/io/openur/global/common/Response.java
@@ -1,10 +1,14 @@
 package io.openur.global.common;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Response<T> {
     private String message;
     private T data;

--- a/src/test/java/io/openur/config/TestSupport.java
+++ b/src/test/java/io/openur/config/TestSupport.java
@@ -2,6 +2,7 @@ package io.openur.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openur.global.common.Response;
 import io.openur.global.jwt.JwtUtil;
 import io.openur.global.security.UserDetailsServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,5 +53,9 @@ public class TestSupport {
     // Implementation of DTO
     protected String jsonify(Object req) throws JsonProcessingException {
         return new ObjectMapper().writeValueAsString(req);
+    }
+
+    protected Response parseResponse(String resString) throws JsonProcessingException {
+        return new ObjectMapper().readValue(resString, Response.class);
     }
 }

--- a/src/test/java/io/openur/controller/HashtagApiTest.java
+++ b/src/test/java/io/openur/controller/HashtagApiTest.java
@@ -1,0 +1,48 @@
+package io.openur.controller;
+
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openur.config.TestSupport;
+import io.openur.global.common.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class HashtagApiTest extends TestSupport {
+
+	private static final String PREFIX = "/v1/bungs";
+
+	@Test
+	@DisplayName("기존 해시태그 조회")
+	void getHashtagsTest() throws Exception {
+		String token = getTestUserToken("test1@test.com");
+		String uriPath = PREFIX + "/hashtags?tag=";
+		Map<String, List<String>> requestAndResponse = Map.of(
+			"런", Arrays.asList("펀런", "런린이"),
+			"고수", List.of("고수만"),
+			"급벙", new ArrayList<>()
+		);
+
+		for (Entry<String, List<String>> entry : requestAndResponse.entrySet()) {
+			MvcResult result = mockMvc.perform(
+				get(uriPath + entry.getKey())
+					.header(AUTH_HEADER, token)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk()).andReturn();
+
+			Response<List<String>> response = parseResponse(
+				result.getResponse().getContentAsString());
+			assert response.getData().containsAll(entry.getValue());
+		}
+	}
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -22,3 +22,17 @@ VALUES (1, 'c0477004-1632-455f-acc9-04584b55921f', '9e1bfc60-f76a-47dc-9147-8036
        (2, 'c0477004-1632-455f-acc9-04584b55921f', '91b4928f-8288-44dc-a04d-640911f0b2be', true,
         CURRENT_TIMESTAMP(), false)
 ;
+
+INSERT INTO tb_hashtags (hashtag_id, hashtag_str)
+VALUES (1, '펀런'),
+       (2, '런린이'),
+       (3, '밤산책'),
+       (4, 'LSD'),
+       (5, '고수만')
+;
+
+INSERT INTO tb_bungs_hashtags (bung_hashtag_id, bung_id, hashtag_id)
+VALUES (1, 'c0477004-1632-455f-acc9-04584b55921f', 1),
+       (2, 'c0477004-1632-455f-acc9-04584b55921f', 2),
+       (3, 'c0477004-1632-455f-acc9-04584b55921f', 3)
+;


### PR DESCRIPTION
# 설명

입력받은 문자열이 포함된 기존 해시태그 리스트 불러오기

연관된 이슈: [BE-55](https://open-run.atlassian.net/browse/BE-55)

## 변경사항

- `findByHashtagStrContaining()` JPA query 추가
- `HashtagController` 생성, 여기에 endpoint 구현
- 해시태그 관련 샘플 데이터 및 조회 테스트 추가

### 변경의 종류 (여러 가지 선택 가능)

- [x] 새로운 기능

# Author 체크리스트

- [x] 테스트를 통과했나요?
- [x] 컴파일 가능한가요?
- [x] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [x] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [x] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [x] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?


[BE-55]: https://open-run.atlassian.net/browse/BE-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ