### PR TITLE
BE-58, fix: save bungsHashtags element for all given hashtag strings

### DIFF
--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -42,8 +42,8 @@ public class BungService {
     }
 
     private void saveHashtags(Bung bung, List<String> hashtagStrList) {
-        List<Hashtag> savedHashtags = hashtagRepository.saveAll(hashtagStrList);
-        bungHashtagRepository.bulkInsertHashtags(bung, savedHashtags);
+        List<Hashtag> hashtags = hashtagRepository.saveAll(hashtagStrList);
+        bungHashtagRepository.bulkInsertHashtags(bung, hashtags);
     }
 
     @Transactional


### PR DESCRIPTION
# 설명

벙을 생성할 때 이미 기존에 존재하는 해시태그 문자열을 입력받은 경우 해당 해시태그가 새로운 벙에 제대로 연결이 되지 않는 버그가 있었음.
relationship 정보인 BungHashtag 데이터가 제대로 저장이 되지 않는 문제였던 것으로 확인, 이를 수정.  

연관된 이슈: [BE-58](https://open-run.atlassian.net/browse/BE-58)

## 변경사항
- `saveHashtags` 로직 수정

### 변경의 종류 (여러 가지 선택 가능)

- [x] 버그 수정

# Author 체크리스트

- [x] 테스트를 통과했나요?
- [x] 컴파일 가능한가요?
- [x] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [x] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [x] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [x] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [x] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?


[BE-58]: https://open-run.atlassian.net/browse/BE-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ