### PR TITLE
[BE-57] add hashtags info to `GET /v1/bungs/{bung-id}` response data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.json:json:20231013'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/io/openur/domain/bung/dto/BungInfoDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/BungInfoDto.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.openur.domain.bung.model.Bung;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class BungInfoDto {
     private String bungId;
     private String name;

--- a/src/main/java/io/openur/domain/bung/dto/BungInfoWithHashtagsDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/BungInfoWithHashtagsDto.java
@@ -3,11 +3,13 @@ package io.openur.domain.bung.dto;
 import io.openur.domain.bung.model.Bung;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class BungInfoWithHashtagsDto extends BungInfoDto {
 
-	private final List<String> hashtags;
+	private List<String> hashtags = List.of();
 
 	public BungInfoWithHashtagsDto(Bung bung, List<String> hashtags) {
 		super(bung);

--- a/src/main/java/io/openur/domain/bung/dto/BungInfoWithMemberListDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/BungInfoWithMemberListDto.java
@@ -8,8 +8,10 @@ import io.openur.domain.userbung.model.UserBung;
 import java.util.List;
 import java.util.Map.Entry;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class BungInfoWithMemberListDto extends BungInfoWithHashtagsDto {
     private List<UserBungInfoDto> memberList;
 

--- a/src/main/java/io/openur/domain/bung/dto/BungInfoWithMemberListDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/BungInfoWithMemberListDto.java
@@ -10,12 +10,14 @@ import java.util.Map.Entry;
 import lombok.Getter;
 
 @Getter
-public class BungInfoWithMemberListDto extends BungInfoDto {
+public class BungInfoWithMemberListDto extends BungInfoWithHashtagsDto {
     private List<UserBungInfoDto> memberList;
 
     public BungInfoWithMemberListDto(
-        Entry<BungEntity, List<UserBungEntity>> entrySet) {
-        super(Bung.from(entrySet.getKey()));
+		Entry<BungEntity, List<UserBungEntity>> entrySet,
+		List<String> hashtags
+	) {
+		super(Bung.from(entrySet.getKey()), hashtags);
 
         this.memberList =
             entrySet.getValue()

--- a/src/main/java/io/openur/domain/userbung/dto/UserBungInfoDto.java
+++ b/src/main/java/io/openur/domain/userbung/dto/UserBungInfoDto.java
@@ -1,9 +1,12 @@
 package io.openur.domain.userbung.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openur.domain.userbung.model.UserBung;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserBungInfoDto {
     private String userId;
     private String nickname;
@@ -12,6 +15,7 @@ public class UserBungInfoDto {
 
     private Long userBungId;
     private boolean participationStatus;
+    @JsonProperty("owner")
     private boolean isOwner;
 
     public UserBungInfoDto(UserBung userBung) {

--- a/src/main/java/io/openur/global/config/QueryDslConfig.java
+++ b/src/main/java/io/openur/global/config/QueryDslConfig.java
@@ -1,6 +1,9 @@
 package io.openur.global.config;
+
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,10 +11,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class QueryDslConfig {
+
+    @PersistenceContext
     private final EntityManager entityManager;
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/test/java/io/openur/config/TestSupport.java
+++ b/src/test/java/io/openur/config/TestSupport.java
@@ -1,7 +1,9 @@
 package io.openur.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openur.global.common.Response;
 import io.openur.global.jwt.JwtUtil;
 import io.openur.global.security.UserDetailsServiceImpl;
@@ -55,7 +57,9 @@ public class TestSupport {
         return new ObjectMapper().writeValueAsString(req);
     }
 
-    protected Response parseResponse(String resString) throws JsonProcessingException {
-        return new ObjectMapper().readValue(resString, Response.class);
+    protected <T> Response<T> parseResponse(String resString, TypeReference<Response<T>> typeReference) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper.readValue(resString, typeReference);
     }
 }

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -5,12 +5,15 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.openur.config.TestSupport;
+import io.openur.domain.bung.dto.BungInfoWithMemberListDto;
 import io.openur.domain.bung.entity.BungEntity;
 import io.openur.domain.bung.repository.BungJpaRepository;
 import io.openur.domain.bunghashtag.repository.BungHashtagRepositoryImpl;
 import io.openur.domain.hashtag.model.Hashtag;
 import io.openur.domain.hashtag.repository.HashtagRepositoryImpl;
+import io.openur.global.common.Response;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -113,6 +116,14 @@ public class BungApiTest extends TestSupport {
                     .header(AUTH_HEADER, token)
                     .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk()).andReturn();
+
+            Response<BungInfoWithMemberListDto> response = parseResponse(
+                result.getResponse().getContentAsString(),
+                new TypeReference<>() {}
+            );
+            assert !response.getData().getHashtags().isEmpty();
+            assert !response.getData().getMemberList().isEmpty();
+            assert response.getData().getMemberList().size() == response.getData().getMemberNumber();
         }
     }
 

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -2,6 +2,7 @@ package io.openur.controller;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openur.config.TestSupport;
@@ -74,6 +75,45 @@ public class BungApiTest extends TestSupport {
             .map(Hashtag::getHashtagStr).toList().containsAll(hashtags);
         assert hashtagRepository.findByHashtagStrIn(hashtags).stream().map(Hashtag::getHashtagStr)
             .toList().containsAll(hashtags);
+    }
+
+    @Nested
+    @DisplayName("벙 정보 상세보기")
+    class getBungDetailTest {
+
+        String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+
+        @Test
+        @DisplayName("403 Forbidden. Authorization Header 없음")
+        @Transactional
+        void getBungDetail_isForbidden() throws Exception {
+            mockMvc.perform(
+                get(PREFIX + "/" + bungId)
+            ).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized. invalid Authorization Header")
+        @Transactional
+        void getBungDetail_isUnauthorized() throws Exception {
+            String invalidToken = "Bearer invalidToken";
+            mockMvc.perform(
+                get(PREFIX + "/" + bungId)
+                    .header(AUTH_HEADER, invalidToken)
+            ).andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("200 OK.")
+        @Transactional
+        void getBungDetail_isOk() throws Exception {
+            String token = getTestUserToken("test3@test.com");  // not owner of the bung
+            MvcResult result = mockMvc.perform(
+                get(PREFIX + "/" + bungId)
+                    .header(AUTH_HEADER, token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+        }
     }
 
     @Nested

--- a/src/test/java/io/openur/controller/HashtagApiTest.java
+++ b/src/test/java/io/openur/controller/HashtagApiTest.java
@@ -4,6 +4,7 @@ package io.openur.controller;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.openur.config.TestSupport;
 import io.openur.global.common.Response;
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ public class HashtagApiTest extends TestSupport {
 			).andExpect(status().isOk()).andReturn();
 
 			Response<List<String>> response = parseResponse(
-				result.getResponse().getContentAsString());
+				result.getResponse().getContentAsString(), new TypeReference<>() {});
 			assert response.getData().containsAll(entry.getValue());
 		}
 	}


### PR DESCRIPTION
# 설명

`GET /v1/bungs/{bung-id}` 응답 데이터에 해시태그 정보 추가. 
또한 해당 엔드포인트 테스트 코드 추가 과정에서 발견한 버그 수정. 

연관된 이슈: [BE-57](https://open-run.atlassian.net/browse/BE-57)

## 변경사항

- a5cf75003596def9be1438a2d6ceffd83f7678e6: querydsl 에러 수정
- d63fba1db929db65b9fe913c4b6801800169b91a: `BungInfoWithMemberListDto` 가 `BungInfoWithHashtagsDto` 를 상속하도록 변경
- a782e997f702895c6fa9d8f24610024e10939020: 해시태그 정보와 멤버리스트 정보까지 올바르게 가져와지는지 테스트

### 변경의 종류 (여러 가지 선택 가능)

- [x] 버그 수정
- [x] 새로운 기능

# Author 체크리스트

- [x] 테스트를 통과했나요?
- [x] 컴파일 가능한가요?
- [x] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [x] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [x] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [x] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?


[BE-57]: https://open-run.atlassian.net/browse/BE-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ