### PR TITLE
BE-61 : 벙에 초대하고자 하는 멤버 리스트 받기 API 추가

### DIFF
--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -2,6 +2,7 @@ package io.openur.domain.bung.controller;
 
 import io.openur.domain.bung.dto.BungInfoDto;
 import io.openur.domain.bung.dto.BungInfoWithMemberListDto;
+import io.openur.domain.bung.dto.BungInvitationDto;
 import io.openur.domain.bung.dto.CreateBungDto;
 import io.openur.domain.bung.model.BungStatus;
 import io.openur.domain.bung.service.BungService;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/bungs")
@@ -100,6 +103,27 @@ public class BungController {
         @PathVariable String bungId
     ) {
         bungService.deleteBung(userDetails, bungId);
+        return ResponseEntity.accepted().body(Response.<Void>builder()
+            .message("success")
+            .build());
+    }
+
+    @PostMapping("/invitation")
+    @Operation(summary = "초대할 사람 리스트 전달")
+    public ResponseEntity<Response<Void>> inviteUsersToBung(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody BungInvitationDto invitationRequest) {
+
+        Long bungId = invitationRequest.getBungId();
+        List<Long> userIdList = invitationRequest.getUserIdList();
+
+        //todo 알람 전송 및 알람 후 ok한 사람들 bundId에 userId 입력해야함.
+        //알람을 보낸 후 처리는 여기서 확인할 필요가 없으니 알람 보내면 그냥 success 보내게 해야됨.
+        //알람을 보내고 signal slot 처럼 알람 response 받으면 bungId에 ok한 사람들 넣는 함수 필요함.
+        //ok한 사람들 확인을 bungService에서 확인하고 직접 넣어주는게 좋아보임. 의견 구함
+
+
+        //근데 response로 return을 보낼 필요가 있나 싶긴함. 우선 넣어둠.
         return ResponseEntity.accepted().body(Response.<Void>builder()
             .message("success")
             .build());

--- a/src/main/java/io/openur/domain/bung/dto/BungInvitationDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/BungInvitationDto.java
@@ -1,0 +1,12 @@
+package io.openur.domain.bung.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class BungInvitationDto {
+    private Long bungId;
+    private List<Long> userIdList;
+
+}


### PR DESCRIPTION
# 설명

{{replace this}}

연관된 이슈: #BE-61

## 변경사항

벙에 초대하고자 하는 멤버 리스트 받기 API 추가
//알람을 보낸 후 처리는 여기서 확인할 필요가 없으니 알람 보내면 그냥 success 보내게 해야됨.
//알람을 보내고 signal slot 처럼 알람 response 받으면 bungId에 ok한 사람들 넣는 함수 필요함.
//ok한 사람들 확인을 bungService에서 확인하고 직접 넣어주는게 좋아보임. 의견 구함


### 변경의 종류 (여러 가지 선택 가능)

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 대규모 변경
- [ ] 문서 업데이트
- [ ] 기타 {{여기에 설명을 추가해 주세요}}

# Author 체크리스트

- [ ] 테스트를 통과했나요?
- [ ] 컴파일 가능한가요?
- [ ] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [ ] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [ ] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?
