### PR TITLE
[BE-62, BE-67] 삭제와 관련된 버그 수정

### DIFF
--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -59,9 +59,10 @@ public class BungService {
         return userBungRepository.findBungWithUsersById(bungId);
     }
 
+    @Transactional
     @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
     public void deleteBung(UserDetailsImpl userDetails, String bungId) {
-        // FIXME: BE-60 해당 bung 과 연관된 user_bung data 도 지워야함
+        userBungRepository.deleteByBungId(bungId);
         bungRepository.deleteByBungId(bungId);
     }
 

--- a/src/main/java/io/openur/domain/userbung/controller/UserBungController.java
+++ b/src/main/java/io/openur/domain/userbung/controller/UserBungController.java
@@ -37,7 +37,7 @@ public class UserBungController {
 	}
 
 	@DeleteMapping("/{bungId}/members/{userIdToRemove}")
-	@Operation(summary = "멤버 삭제하기(벙주만 가능)")
+	@Operation(summary = "멤버 삭제하기(벙주와 본인만 가능)")
 	public ResponseEntity<Response<Void>> kickMember(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable String bungId,

--- a/src/main/java/io/openur/domain/userbung/exception/RemoveUserFromBungException.java
+++ b/src/main/java/io/openur/domain/userbung/exception/RemoveUserFromBungException.java
@@ -1,0 +1,8 @@
+package io.openur.domain.userbung.exception;
+
+public class RemoveUserFromBungException extends RuntimeException {
+
+    public RemoveUserFromBungException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungJpaRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungJpaRepository.java
@@ -4,7 +4,6 @@ import io.openur.domain.user.entity.UserEntity;
 import io.openur.domain.userbung.entity.UserBungEntity;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,5 +16,7 @@ public interface UserBungJpaRepository extends JpaRepository<UserBungEntity, Lon
     Page<UserBungEntity> findAllByUserEntityAndOwnerIsTrueOrderByUserBungIdDesc(UserEntity userEntity, Pageable pageable);
 
 	List<UserBungEntity> findByBungEntity_BungId(String bungId);
+
+	void deleteByBungEntity_BungId(String bungId);
 
 }

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -27,4 +27,6 @@ public interface UserBungRepository {
     UserBung findCurrentOwner(String bungId);
 
     void removeUserFromBung(UserBung userBung);
+
+    void deleteByBungId(String bungId);
 }

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -173,6 +173,11 @@ public class UserBungRepositoryImpl implements UserBungRepository {
         userBungJpaRepository.delete(userBung.toEntity());
     }
 
+    @Override
+    public void deleteByBungId(String bungId) {
+        userBungJpaRepository.deleteByBungEntity_BungId(bungId);
+    }
+
     private BooleanExpression ownedBungsOnly(Boolean isOwned) {
         if (isOwned == null) {
             return null;

--- a/src/main/java/io/openur/domain/userbung/service/UserBungService.java
+++ b/src/main/java/io/openur/domain/userbung/service/UserBungService.java
@@ -29,7 +29,8 @@ public class UserBungService {
 	}
 
 	@Transactional
-	@PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
+	@PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId) || "
+		+ "@methodSecurityService.isSelf(#userDetails, #userIdToRemove)")
 	public void removeUserFromBung(UserDetailsImpl userDetails, String bungId,
 		String userIdToRemove) {
 		UserBung userBung = userBungRepository.findByUserIdAndBungId(userIdToRemove, bungId);

--- a/src/main/java/io/openur/global/exception/ExceptionController.java
+++ b/src/main/java/io/openur/global/exception/ExceptionController.java
@@ -1,6 +1,7 @@
 package io.openur.global.exception;
 
 import io.openur.domain.bung.exception.JoinBungException;
+import io.openur.domain.userbung.exception.RemoveUserFromBungException;
 import io.openur.global.dto.ExceptionDto;
 import io.openur.global.jwt.InvalidJwtException;
 import java.awt.HeadlessException;
@@ -35,7 +36,7 @@ public class ExceptionController {
 			e.getBindingResult().getFieldError().getDefaultMessage());
 	}
 
-	@ExceptionHandler({AccessDeniedException.class})
+	@ExceptionHandler({AccessDeniedException.class, RemoveUserFromBungException.class})
 	public ResponseEntity<ExceptionDto> handleForbiddenException(Exception e) {
 		return createResponse(HttpStatus.FORBIDDEN, e.getMessage());
 	}

--- a/src/main/java/io/openur/global/security/MethodSecurityService.java
+++ b/src/main/java/io/openur/global/security/MethodSecurityService.java
@@ -2,6 +2,7 @@ package io.openur.global.security;
 
 import io.openur.domain.userbung.model.UserBung;
 import io.openur.domain.userbung.repository.UserBungRepositoryImpl;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
@@ -16,9 +17,13 @@ public class MethodSecurityService {
 
 	public boolean isOwnerOfBung(@AuthenticationPrincipal UserDetailsImpl userDetails,
 		String bungId) {
-		UserBung userBung = userBungRepository.findByUserIdAndBungId(
-			userDetails.getUser().getUserId(), bungId);
-		return userBung.isOwner();
+		try {
+			UserBung userBung = userBungRepository.findByUserIdAndBungId(
+				userDetails.getUser().getUserId(), bungId);
+			return userBung.isOwner();
+		} catch (NoSuchElementException e) {
+			return false;
+		}
 	}
 
 	public boolean isSelf(@AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/io/openur/global/security/MethodSecurityService.java
+++ b/src/main/java/io/openur/global/security/MethodSecurityService.java
@@ -20,4 +20,9 @@ public class MethodSecurityService {
 			userDetails.getUser().getUserId(), bungId);
 		return userBung.isOwner();
 	}
+
+	public boolean isSelf(@AuthenticationPrincipal UserDetailsImpl userDetails,
+		String userId) {
+		return userDetails.getUser().getUserId().equals(userId);
+	}
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS tb_users_bungs (
                                              user_bung_id BIGINT(20) AUTO_INCREMENT PRIMARY KEY NOT NULL,
                                              bung_id VARCHAR(36) DEFAULT (UUID()) NOT NULL,
                                              user_id VARCHAR(36) DEFAULT (UUID()) NOT NULL,
-                                             FOREIGN KEY (bung_id) REFERENCES tb_bungs (bung_id), -- TODO: CASCADE 설정
+                                             FOREIGN KEY (bung_id) REFERENCES tb_bungs (bung_id),
                                              FOREIGN KEY (user_id) REFERENCES tb_users(user_id),
                                              participation_status BOOLEAN DEFAULT FALSE NOT NULL, -- TODO: 벙 참여 인증 완료 했을 때 사용할 값
                                              modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -1,5 +1,6 @@
 package io.openur.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -15,6 +16,7 @@ import io.openur.domain.bung.repository.BungJpaRepository;
 import io.openur.domain.bunghashtag.repository.BungHashtagRepositoryImpl;
 import io.openur.domain.hashtag.model.Hashtag;
 import io.openur.domain.hashtag.repository.HashtagRepositoryImpl;
+import io.openur.domain.userbung.repository.UserBungJpaRepository;
 import io.openur.global.common.PagedResponse;
 import io.openur.global.common.Response;
 import io.openur.global.dto.ExceptionDto;
@@ -38,6 +40,8 @@ public class BungApiTest extends TestSupport {
 	private static final String PREFIX = "/v1/bungs";
 	@Autowired
 	protected BungJpaRepository bungJpaRepository;
+	@Autowired
+	protected UserBungJpaRepository userBungJpaRepository;
 	@Autowired
 	protected HashtagRepositoryImpl hashtagRepository;
 	@Autowired
@@ -226,7 +230,6 @@ public class BungApiTest extends TestSupport {
 
 		@Test
 		@DisplayName("403 Forbidden. Authorization Header 없음")
-		@Transactional
 		void deleteBung_isForbidden() throws Exception {
 			mockMvc.perform(
 					delete(PREFIX + "/" + bungId)
@@ -236,7 +239,6 @@ public class BungApiTest extends TestSupport {
 
 		@Test
 		@DisplayName("403 Forbidden. Bung owner 가 아닌 경우")
-		@Transactional
 		void deleteBung_isForbidden_notOwner() throws Exception {
 			String notOwnerToken = getTestUserToken("test2@test.com");
 			mockMvc.perform(
@@ -247,7 +249,6 @@ public class BungApiTest extends TestSupport {
 
 		@Test
 		@DisplayName("401 Unauthorized. invalid Authorization Header")
-		@Transactional
 		void deleteBung_isUnauthorized() throws Exception {
 			String invalidToken = "Bearer invalidToken";
 			mockMvc.perform(
@@ -258,7 +259,6 @@ public class BungApiTest extends TestSupport {
 
 		@Test
 		@DisplayName("401 Unauthorized. Unknown user token")
-		@Transactional
 		void deleteBung_isUnauthorized_unknownUser() throws Exception {
 			String unknownUserToken = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ5ZWppbmtlbGx5am9vQGdtYWlsLmNvbSIsImV4cCI6MTcyMzYyNDgxMCwiaWF0IjoxNzIzNjIxMjEwfQ.wH-eJCvEBgFg_QjWr7CdxBpMqlQzGt45DLmrsWju-HU";
 			mockMvc.perform(
@@ -269,13 +269,15 @@ public class BungApiTest extends TestSupport {
 
 		@Test
 		@DisplayName("200 Ok.")
-		@Transactional
 		void deleteBung_isOk() throws Exception {
 			String token = getTestUserToken("test1@test.com");
 			mockMvc.perform(
 				delete(PREFIX + "/" + bungId)
 					.header(AUTH_HEADER, token)
 			).andExpect(status().isOk());
+
+			assertThat(bungJpaRepository.findById(bungId)).isEmpty();
+			assertThat(userBungJpaRepository.findByBungEntity_BungId(bungId)).isEmpty();
 		}
 
 	}

--- a/src/test/java/io/openur/controller/UserBungApiTest.java
+++ b/src/test/java/io/openur/controller/UserBungApiTest.java
@@ -25,21 +25,41 @@ public class UserBungApiTest extends TestSupport {
 
 	private static final String PREFIX = "/v1/bungs";
 
-	@Test
+	@Nested
 	@DisplayName("멤버 제거")
-	void kickMember_successTest() throws Exception {
-		String token = getTestUserToken("test1@test.com");
-		String bungId = "c0477004-1632-455f-acc9-04584b55921f";
-		String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
+	class kickMemberTest {
 
-		mockMvc.perform(
-			delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
-				.header(AUTH_HEADER, token)
-				.contentType(MediaType.APPLICATION_JSON)
-		).andExpect(status().isOk());
+		@Test
+		@DisplayName("200 Ok. Is bung owner.")
+		@Transactional
+		void kickMember_successTest() throws Exception {
+			String token = getTestUserToken("test1@test.com");
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
 
-		assertThatThrownBy(() -> userBungRepository.findByUserIdAndBungId(userIdToKick, bungId))
-			.isInstanceOf(NoSuchElementException.class);
+			mockMvc.perform(
+				delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
+					.header(AUTH_HEADER, token)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk());
+		}
+
+		@Test
+		@DisplayName("200 Ok. Is self.")
+		void kickMember_success_isSelf() throws Exception {
+			String token = getTestUserToken("test2@test.com");
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			mockMvc.perform(
+				delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
+					.header(AUTH_HEADER, token)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk());
+
+			assertThatThrownBy(() -> userBungRepository.findByUserIdAndBungId(userIdToKick, bungId))
+				.isInstanceOf(NoSuchElementException.class);
+		}
 	}
 
 	@Nested

--- a/src/test/java/io/openur/controller/UserBungApiTest.java
+++ b/src/test/java/io/openur/controller/UserBungApiTest.java
@@ -83,6 +83,27 @@ public class UserBungApiTest extends TestSupport {
 			assert Objects.equals(response.getMessage(),
 				"Owners cannot remove themselves from bung.");
 		}
+
+		@Test
+		@DisplayName("403 Forbidden. Is not owner nor self.")
+		void kickMember_isForbidden_notOwnerNorSelf() throws Exception {
+			String token = getTestUserToken("test3@test.com");
+			String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+			String userIdToKick = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+			MvcResult result = mockMvc.perform(
+				delete(PREFIX + "/{bungId}/members/{userIdToKick}", bungId, userIdToKick)
+					.header(AUTH_HEADER, token)
+					.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isForbidden()).andReturn();
+
+			ExceptionDto response = parseResponse(
+				result.getResponse().getContentAsString(), new TypeReference<>() {
+				});
+			assert Objects.equals(response.getMessage(),
+				"Must be the owner of bung or self to remove user from bung.");
+		}
+
 	}
 
 	@Nested


### PR DESCRIPTION
# 설명

1. BE-67. 멤버 삭제하기가 현재 벙주만 가능. 본인도 가능하도록 수정
2. BE-62. 벙 삭제 시 벙에 참여한 멤버 관련 데이터도 삭제해줘야함


연관된 이슈: #{{이슈 번호}}

## 변경사항

 - 036f86409ceb21912bde60bc80e97a366522dd00 : @PreAuthorize 에 조건 추가
 - a35039155e715be9e8189b7481aecb78f4a7b307 : 벙 데이터 삭제 전 유저벙 데이터 먼저 삭제

### 변경의 종류 (여러 가지 선택 가능)

- [x] 버그 수정

# Author 체크리스트

- [x] 테스트를 통과했나요?
- [x] 컴파일 가능한가요?
- [x] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [x] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [x] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [x] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [x] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?
