### PR TITLE
BE-66, fix : 벙 참가자 수 수정 시 이미 참가중인 인원 미만 숫자로 변경 불가하도록 제한 설정

### DIFF
--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -161,13 +161,7 @@ public class BungController {
         @RequestBody EditBungDto editBungDto
     ) {
         EditBungResultEnum result = bungService.editBung(userDetails, bungId, editBungDto);
-        if (result != EditBungResultEnum.SUCCESSFULLY_EDITED) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(Response.<EditBungResultEnum>builder()
-                    .message(result.toString())
-                    .data(result)
-                    .build());
-        }
+
         return ResponseEntity.ok().body(Response.<EditBungResultEnum>builder()
             .message(result.toString())
             .data(result)

--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -160,6 +161,13 @@ public class BungController {
         @RequestBody EditBungDto editBungDto
     ) {
         EditBungResultEnum result = bungService.editBung(userDetails, bungId, editBungDto);
+        if (result != EditBungResultEnum.SUCCESSFULLY_EDITED) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Response.<EditBungResultEnum>builder()
+                    .message(result.toString())
+                    .data(result)
+                    .build());
+        }
         return ResponseEntity.ok().body(Response.<EditBungResultEnum>builder()
             .message(result.toString())
             .data(result)

--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -161,7 +160,6 @@ public class BungController {
         @RequestBody EditBungDto editBungDto
     ) {
         EditBungResultEnum result = bungService.editBung(userDetails, bungId, editBungDto);
-
         return ResponseEntity.ok().body(Response.<EditBungResultEnum>builder()
             .message(result.toString())
             .data(result)

--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -157,7 +158,7 @@ public class BungController {
     public ResponseEntity<Response<EditBungResultEnum>> editBung(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable String bungId,
-        @RequestBody EditBungDto editBungDto
+        @RequestBody @Valid EditBungDto editBungDto
     ) {
         EditBungResultEnum result = bungService.editBung(userDetails, bungId, editBungDto);
         return ResponseEntity.ok().body(Response.<EditBungResultEnum>builder()

--- a/src/main/java/io/openur/domain/bung/dto/EditBungDto.java
+++ b/src/main/java/io/openur/domain/bung/dto/EditBungDto.java
@@ -2,21 +2,31 @@ package io.openur.domain.bung.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class EditBungDto {
 
+    @NotBlank
     private String name;
+    @NotBlank
     private String description;
 
     @Min(3)
     @Max(300)
+    @NotNull
     private Integer memberNumber;
 
+    @NotNull
     private Boolean hasAfterRun;
+    @NotBlank
     private String afterRunDescription;
+    @NotEmpty
     private List<String> hashtags;
+    @NotBlank
     private String mainImage;
 }

--- a/src/main/java/io/openur/domain/bung/enums/EditBungResultEnum.java
+++ b/src/main/java/io/openur/domain/bung/enums/EditBungResultEnum.java
@@ -4,6 +4,7 @@ public enum EditBungResultEnum {
     SUCCESSFULLY_EDITED("successfully edited"),
     BUNG_HAS_ALREADY_COMPLETED("You cannot edit bung - bung has already completed"),
     BUNG_HAS_ALREADY_STARTED("You cannot edit bung - bung has already started"),
+    BUNG_PARTICIPANTS_EXCEEDED("You cannot edit bung - current members exceed the allowed limit")
     ;
 
     private final String value;

--- a/src/main/java/io/openur/domain/bung/exception/CompleteBungException.java
+++ b/src/main/java/io/openur/domain/bung/exception/CompleteBungException.java
@@ -1,8 +1,10 @@
 package io.openur.domain.bung.exception;
 
+import io.openur.domain.bung.enums.CompleteBungResultEnum;
+
 public class CompleteBungException extends RuntimeException {
 
-    public CompleteBungException(String message) {
-        super(message);
+    public CompleteBungException(CompleteBungResultEnum completeBungResultEnum) {
+        super(completeBungResultEnum.toString());
     }
 }

--- a/src/main/java/io/openur/domain/bung/exception/EditBungException.java
+++ b/src/main/java/io/openur/domain/bung/exception/EditBungException.java
@@ -1,8 +1,10 @@
 package io.openur.domain.bung.exception;
 
+import io.openur.domain.bung.enums.EditBungResultEnum;
+
 public class EditBungException extends RuntimeException {
 
-    public EditBungException(String message) {
-        super(message);
+    public EditBungException(EditBungResultEnum editBungResultEnum) {
+        super(editBungResultEnum.toString());
     }
 }

--- a/src/main/java/io/openur/domain/bung/exception/JoinBungException.java
+++ b/src/main/java/io/openur/domain/bung/exception/JoinBungException.java
@@ -1,8 +1,10 @@
 package io.openur.domain.bung.exception;
 
+import io.openur.domain.bung.enums.JoinBungResultEnum;
+
 public class JoinBungException extends RuntimeException {
 
-    public JoinBungException(String message) {
-        super(message);
+    public JoinBungException(JoinBungResultEnum joinBungResultEnum) {
+        super(joinBungResultEnum.toString());
     }
 }

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -115,7 +115,7 @@ public class BungService {
     @Transactional
     public JoinBungResultEnum joinBung(UserDetailsImpl userDetails, String bungId) throws JoinBungException {
         if (bungRepository.isBungStarted(bungId)) {
-            throw new JoinBungException(JoinBungResultEnum.BUNG_HAS_ALREADY_STARTED.toString());
+            throw new JoinBungException(JoinBungResultEnum.BUNG_HAS_ALREADY_STARTED);
         }
 
         BungInfoWithMemberListDto bungWithMembers = userBungRepository.findBungWithUsersById(
@@ -123,11 +123,11 @@ public class BungService {
         if (bungWithMembers.getMemberList().stream().anyMatch(
                 user -> user.getUserId().equals(userDetails.getUser().getUserId())
         )) {
-            throw new JoinBungException(JoinBungResultEnum.USER_HAS_ALREADY_JOINED.toString());
+            throw new JoinBungException(JoinBungResultEnum.USER_HAS_ALREADY_JOINED);
         }
 
         if (bungWithMembers.getMemberList().size() == bungWithMembers.getMemberNumber()) {
-            throw new JoinBungException(JoinBungResultEnum.BUNG_IS_FULL.toString());
+            throw new JoinBungException(JoinBungResultEnum.BUNG_IS_FULL);
         }
 
         userBungRepository.save(new UserBung(userDetails.getUser(), new Bung(bungWithMembers)));
@@ -140,16 +140,16 @@ public class BungService {
         Bung bung = bungRepository.findBungById(bungId);
 
         if (bung.isCompleted()) {
-            throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_COMPLETED.toString());
+            throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_COMPLETED);
         }
 
         if (bung.getStartDateTime().isBefore(LocalDateTime.now())) {
-            throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_STARTED.toString());
+            throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_STARTED);
         }
 
         int numberOfCurrentMember = userBungRepository.countParticipantsByBungId(bungId);
         if(editBungDto.getMemberNumber() < numberOfCurrentMember) {
-            throw new EditBungException(EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED.toString());
+            throw new EditBungException(EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED);
         }
 
         bung.update(editBungDto);
@@ -166,11 +166,11 @@ public class BungService {
     ) throws CompleteBungException {
         Bung bung = bungRepository.findBungById(bungId);
         if (bung.isCompleted()) {
-            throw new CompleteBungException(CompleteBungResultEnum.BUNG_HAS_ALREADY_COMPLETED.toString());
+            throw new CompleteBungException(CompleteBungResultEnum.BUNG_HAS_ALREADY_COMPLETED);
         }
 
         if (bung.getStartDateTime().isAfter(LocalDateTime.now())) {
-            throw new CompleteBungException(CompleteBungResultEnum.BUNG_HAS_NOT_STARTED.toString());
+            throw new CompleteBungException(CompleteBungResultEnum.BUNG_HAS_NOT_STARTED);
         }
 
         //TODO: EventPublisher 로 도전과제 부가 기능 연산 필요, 도전과제에 따라 bung 이 가진 필드를 가져가는 DTO 가 필요할것

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -147,7 +147,6 @@ public class BungService {
             throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_STARTED.toString());
         }
 
-        //프론트 요청 사항으로 return으로 result 값 0이 아닌 다른 값으로 보내고 메시지도 달라고 했음.
         int numberOfCurrentMember = userBungRepository.countParticipantsByBungId(bungId);
         if(editBungDto.getMemberNumber() < numberOfCurrentMember) {
             throw new EditBungException(EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED.toString());

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -148,7 +148,7 @@ public class BungService {
         }
 
         int numberOfCurrentMember = userBungRepository.countParticipantsByBungId(bungId);
-        if(editBungDto.getMemberNumber() < numberOfCurrentMember) {
+        if (editBungDto.getMemberNumber() < numberOfCurrentMember) {
             throw new EditBungException(EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED);
         }
 

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -150,7 +150,7 @@ public class BungService {
         //프론트 요청 사항으로 return으로 result 값 0이 아닌 다른 값으로 보내고 메시지도 달라고 했음.
         int numberOfCurrentMember = userBungRepository.countParticipantsByBungId(bungId);
         if(editBungDto.getMemberNumber() < numberOfCurrentMember) {
-            return EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED;
+            throw new EditBungException(EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED.toString());
         }
 
         bung.update(editBungDto);

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -147,6 +147,12 @@ public class BungService {
             throw new EditBungException(EditBungResultEnum.BUNG_HAS_ALREADY_STARTED.toString());
         }
 
+        //프론트 요청 사항으로 return으로 result 값 0이 아닌 다른 값으로 보내고 메시지도 달라고 했음.
+        int numberOfCurrentMember = userBungRepository.countParticipantsByBungId(bungId);
+        if(editBungDto.getMemberNumber() < numberOfCurrentMember) {
+            return EditBungResultEnum.BUNG_PARTICIPANTS_EXCEEDED;
+        }
+
         bung.update(editBungDto);
         updateHashtags(bung, editBungDto.getHashtags());
         bungRepository.save(bung);

--- a/src/main/java/io/openur/domain/user/controller/UserController.java
+++ b/src/main/java/io/openur/domain/user/controller/UserController.java
@@ -167,7 +167,7 @@ public class UserController {
     })
     public ResponseEntity<Response<List<String>>> increaseFeedback(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestBody GetFeedbackDto feedbackRequestDto) {
+        @RequestBody @Valid GetFeedbackDto feedbackRequestDto) {
         List<String> notFoundUserIds = userService.increaseFeedback(userDetails,
             feedbackRequestDto.getBungId(),
             feedbackRequestDto.getTargetUserIds());

--- a/src/main/java/io/openur/domain/user/dto/GetFeedbackDto.java
+++ b/src/main/java/io/openur/domain/user/dto/GetFeedbackDto.java
@@ -1,12 +1,16 @@
 package io.openur.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class GetFeedbackDto {
 
+    @NotEmpty
     private List<String> targetUserIds;
+    @NotBlank
     private String bungId;
 
 }

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserBungRepository {
 
-    Integer countParticipantsByBungId(String bungId);
+    int countParticipantsByBungId(String bungId);
 
     BungInfoWithMemberListDto findBungWithUsersById(String bungId);
 

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface UserBungRepository {
 
+    Integer countParticipantsByBungId(String bungId);
+
     BungInfoWithMemberListDto findBungWithUsersById(String bungId);
 
     Page<Tuple> findAllFrequentUsers(List<String> bungIds, User user, Pageable pageable);

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +40,17 @@ public class UserBungRepositoryImpl implements UserBungRepository {
 
     private final UserBungJpaRepository userBungJpaRepository;
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Integer countParticipantsByBungId(String bungId){
+        return Objects.requireNonNull(queryFactory
+            .select(userBungEntity.count())
+            .from(userBungEntity)
+            .where(userBungEntity.bungEntity.bungId.eq(bungId))
+            .fetchOne())
+            .intValue();
+    }
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,12 +42,12 @@ public class UserBungRepositoryImpl implements UserBungRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Integer countParticipantsByBungId(String bungId){
-        return Objects.requireNonNull(queryFactory
+    public int countParticipantsByBungId(String bungId) {
+        return queryFactory
             .select(userBungEntity.count())
             .from(userBungEntity)
             .where(userBungEntity.bungEntity.bungId.eq(bungId))
-            .fetchOne())
+            .fetchOne()
             .intValue();
     }
 

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -25,7 +25,6 @@ import io.openur.domain.userbung.repository.UserBungJpaRepository;
 import io.openur.global.common.PagedResponse;
 import io.openur.global.common.Response;
 import io.openur.global.dto.ExceptionDto;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -376,8 +375,27 @@ public class BungApiTest extends TestSupport {
     @Nested
     @DisplayName("벙 수정하기")
     class editBungTest {
+
+        HashMap<Object, Object> getEditBungData() {
+            var editBungData = new HashMap<>();
+            editBungData.put("name", "새로운 이름");
+            editBungData.put("description", "새로운 설명");
+            editBungData.put("memberNumber", 5);
+            editBungData.put("hasAfterRun", true);
+            editBungData.put("afterRunDescription", "단백질 보충 가시죠! 고기고기");
+            editBungData.put("hashtags", getHashtags());
+            editBungData.put("mainImage", "image2.jpg");
+            return editBungData;
+        }
+
+        List<String> getHashtags() {
+            return Arrays.asList("LSD", "음악있음", "고수만");
+
+        }
+
+
         @Test
-        @DisplayName("200 Ok. No elements.")
+        @DisplayName("400 Bad Request. No elements.")
         void editBung_isOk_noElements() throws Exception {
             String bungId = "c0477004-1632-455f-acc9-04584b55921f";
             String ownerToken = getTestUserToken("test1@test.com");
@@ -386,7 +404,7 @@ public class BungApiTest extends TestSupport {
                     .header(AUTH_HEADER, ownerToken)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonify(new HashMap<>()))
-            ).andExpect(status().isOk());
+            ).andExpect(status().isBadRequest());
         }
 
         @Test
@@ -398,7 +416,7 @@ public class BungApiTest extends TestSupport {
                 patch(PREFIX + "/" + bungId)
                     .header(AUTH_HEADER, notOwnerToken)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(jsonify(new HashMap<>()))
+                    .content(jsonify(getEditBungData()))
             ).andExpect(status().isForbidden());
         }
 
@@ -412,7 +430,7 @@ public class BungApiTest extends TestSupport {
                 patch(PREFIX + "/" + bungId)
                     .header(AUTH_HEADER, ownerToken)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(jsonify(new HashMap<>()))
+                    .content(jsonify(getEditBungData()))
             ).andExpect(status().isForbidden()).andReturn();
 
             ExceptionDto response = parseResponse(
@@ -433,15 +451,8 @@ public class BungApiTest extends TestSupport {
                     .map(Hashtag::getHashtagStr)
                     .toList();
 
-            var editBungData = new HashMap<>();
-            editBungData.put("name", "새로운 이름");
-            editBungData.put("description", "새로운 설명");
-            editBungData.put("memberNumber", 5);
-            editBungData.put("hasAfterRun", true);
-            editBungData.put("afterRunDescription", "단백질 보충 가시죠! 고기고기");
-            List<String> hashtags = Arrays.asList("LSD", "음악있음", "고수만");
-            editBungData.put("hashtags", hashtags);
-            editBungData.put("mainImage", "image2.jpg");
+            HashMap<Object, Object> editBungData = getEditBungData();
+            List<String> hashtags = getHashtags();
 
             mockMvc.perform(
                     patch(PREFIX + "/" + bungId)


### PR DESCRIPTION
# 설명

벙 참가자 수 수정 시 이미 참가중인 인원 미만 숫자로 변경 불가하도록 제한 설정

{{replace this}}

연관된 이슈: #{{BE-66}}

## 변경사항

벙 참가자 수 수정 시 이미 참가중인 인원 미만 숫자로 변경 불가하도록 제한 설정.
추가로 프론트에서 response 요청 방식이 바뀔 수 있어서 추가 commit 올라갈 수도 있음.
사람 수 세는 querydsl 새로 만듦.
이거를 다른 멤버리스트.size 부분 교체할 지도 고려 중

### 변경의 종류 (여러 가지 선택 가능)

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 대규모 변경
- [ ] 문서 업데이트
- [ ] 기타 {{여기에 설명을 추가해 주세요}}

# Author 체크리스트

- [ ] 테스트를 통과했나요?
- [ ] 컴파일 가능한가요?
- [ ] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [ ] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [ ] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?
