### PR TITLE
[BE-91] 로그인 Provider에 Smart Wallet 추가

### DIFF
--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -49,7 +49,7 @@ public class BungService {
     private final ChallengeEventsPublisher challengeEventsPublisher;
 
     private Bung saveNewBung(UserDetailsImpl userDetails, CreateBungDto dto) {
-        User user = userRepository.findByEmail(userDetails.getUser().getEmail());
+        User user = userRepository.findUser(userDetails.getUser());
         Bung bung = bungRepository.save(new Bung(dto));
         userBungRepository.save(UserBung.isOwnerBung(user, bung));
         return bung;
@@ -91,7 +91,7 @@ public class BungService {
         boolean isAvailableOnly,
         Pageable pageable
     ) {
-        User user = userRepository.findByEmail(userDetails.getUser().getEmail());
+        User user = userRepository.findUser(userDetails.getUser());
 
         return bungRepository
             .findBungsWithStatus(user, isAvailableOnly, pageable);
@@ -103,7 +103,7 @@ public class BungService {
         BungStatus status,
         Pageable pageable
     ) {
-        User user = userRepository.findByEmail(userDetails.getUser().getEmail());
+        User user = userRepository.findUser(userDetails.getUser());
 
         return userBungRepository
             .findJoinedBungsByUserWithStatus(user, isOwned, status, pageable)

--- a/src/main/java/io/openur/domain/user/dto/GetUsersLoginDto.java
+++ b/src/main/java/io/openur/domain/user/dto/GetUsersLoginDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GetUsersLoginDto {
 
-    private final String email;
+    private final String identifier;  // Can be email or blockchain address
     private final String nickname;
     private final String jwtToken;
 }

--- a/src/main/java/io/openur/domain/user/dto/SmartWalletUserInfoDto.java
+++ b/src/main/java/io/openur/domain/user/dto/SmartWalletUserInfoDto.java
@@ -1,0 +1,16 @@
+package io.openur.domain.user.dto;
+
+import io.openur.domain.user.model.Provider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SmartWalletUserInfoDto {
+    private final String blockchainAddress;
+    private final Provider provider;
+
+    public static SmartWalletUserInfoDto of(String blockchainAddress) {
+        return new SmartWalletUserInfoDto(blockchainAddress, Provider.smart_wallet);
+    }
+} 

--- a/src/main/java/io/openur/domain/user/model/Provider.java
+++ b/src/main/java/io/openur/domain/user/model/Provider.java
@@ -1,5 +1,5 @@
 package io.openur.domain.user.model;
 
 public enum Provider {
-    kakao, naver
+    kakao, naver, smart_wallet
 }

--- a/src/main/java/io/openur/domain/user/model/User.java
+++ b/src/main/java/io/openur/domain/user/model/User.java
@@ -47,6 +47,21 @@ public class User {
         this.feedback = 0;
     }
 
+    public User(String blockchainAddress) {
+        this.userId = UUID.randomUUID().toString();
+        this.nickname = null;
+        this.email = null;
+        this.identityAuthenticated = false;
+        this.provider = Provider.smart_wallet;
+        this.blacklisted = false;
+        this.createdDate = LocalDateTime.now();
+        this.lastLoginDate = LocalDateTime.now();
+        this.blockchainAddress = blockchainAddress;
+        this.runningPace = null;
+        this.runningFrequency = null;
+        this.feedback = 0;
+    }
+
     public static User from(final UserEntity userEntity) {
         return new User(
             userEntity.getUserId(),
@@ -78,10 +93,8 @@ public class User {
             runningPace,
             runningFrequency,
             feedback
-
         );
     }
-
 
     public void update(PatchUserSurveyRequestDto patchUserSurveyRequestDto) {
         applyIfNotNull(patchUserSurveyRequestDto.getNickname(), newNickname -> this.nickname = newNickname);

--- a/src/main/java/io/openur/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/UserJpaRepository.java
@@ -9,6 +9,8 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, String> {
 
     Optional<UserEntity> findByEmail(String email);
 
+    Optional<UserEntity> findByBlockchainAddress(String blockchainAddress);
+
     Optional<UserEntity> findByUserId(String userId);
 
     List<UserEntity> findAllByNicknameContains(String nickname);

--- a/src/main/java/io/openur/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepository.java
@@ -1,9 +1,7 @@
 package io.openur.domain.user.repository;
 
-
 import io.openur.domain.user.model.User;
 import java.util.List;
-
 
 public interface UserRepository {
     // QUESTION: What is the purpose of this interface repository?
@@ -11,9 +9,7 @@ public interface UserRepository {
 
     User save(User user);
 
-    User findByEmail(String email);
-
-    User findByBlockchainAddress(String blockchainAddress);
+    User findUser(User user);  // Will use email or blockchain address based on what's available
 
     User findById(String userId);
 

--- a/src/main/java/io/openur/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepository.java
@@ -13,6 +13,8 @@ public interface UserRepository {
 
     User findByEmail(String email);
 
+    User findByBlockchainAddress(String blockchainAddress);
+
     User findById(String userId);
 
     List<User> findByUserNickname(String nickName);

--- a/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
@@ -30,6 +30,16 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public User findByBlockchainAddress(String blockchainAddress) {
+        UserEntity userEntity = userJpaRepository.findByBlockchainAddress(blockchainAddress).orElse(null);
+        if (userEntity == null) {
+            return null;
+        } else {
+            return User.from(userEntity);
+        }
+    }
+
+    @Override
     public User findById(String userId) {
         UserEntity userEntity = userJpaRepository.findByUserId(userId)
             .orElseThrow(() -> new NoSuchElementException("User not found"));

--- a/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
@@ -20,7 +20,24 @@ public class UserRepositoryImpl implements UserRepository {
     private EntityManager entityManager;
 
     @Override
-    public User findByEmail(String email) {
+    public User findUser(User user) {
+        // Try to find by email first if available
+        if (user.getEmail() != null && !user.getEmail().isEmpty()) {
+            User foundUser = findByEmail(user.getEmail());
+            if (foundUser != null) {
+                return foundUser;
+            }
+        }
+        
+        // If email not found or not available, try blockchain address
+        if (user.getBlockchainAddress() != null && !user.getBlockchainAddress().matches("0x")) {
+            return findByBlockchainAddress(user.getBlockchainAddress());
+        }
+        
+        return null;
+    }
+
+    private User findByEmail(String email) {
         UserEntity userEntity = userJpaRepository.findByEmail(email).orElse(null);
         if (userEntity == null) {
             return null;
@@ -29,8 +46,7 @@ public class UserRepositoryImpl implements UserRepository {
         }
     }
 
-    @Override
-    public User findByBlockchainAddress(String blockchainAddress) {
+    private User findByBlockchainAddress(String blockchainAddress) {
         UserEntity userEntity = userJpaRepository.findByBlockchainAddress(blockchainAddress).orElse(null);
         if (userEntity == null) {
             return null;

--- a/src/main/java/io/openur/domain/user/service/UserService.java
+++ b/src/main/java/io/openur/domain/user/service/UserService.java
@@ -25,8 +25,7 @@ public class UserService {
     private final UserBungRepositoryImpl userBungRepositoryImpl;
 
     public String getUserById(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        String email = userDetails.getUser().getEmail();
-        User user = userRepository.findByEmail(email);
+        User user = userRepository.findUser(userDetails.getUser());
         return user.getUserId();
     }
 
@@ -35,8 +34,7 @@ public class UserService {
     }
 
     public GetUserResponseDto getUserEmail(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        String email = userDetails.getUser().getEmail();
-        User user = userRepository.findByEmail(email);
+        User user = userRepository.findUser(userDetails.getUser());
         return new GetUserResponseDto(user);
     }
 
@@ -56,15 +54,14 @@ public class UserService {
 
     @Transactional
     public void deleteUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        User user = userRepository.findByEmail(userDetails.getUser().getEmail());
+        User user = userRepository.findUser(userDetails.getUser());
         userRepository.deleteUserInfo(user);
     }
 
     @Transactional
     public void saveSurveyResult(@AuthenticationPrincipal UserDetailsImpl userDetails,
         PatchUserSurveyRequestDto patchUserSurveyRequestDto) {
-        String email = userDetails.getUser().getEmail();
-        User user = userRepository.findByEmail(email);
+        User user = userRepository.findUser(userDetails.getUser());
         user.update(patchUserSurveyRequestDto);
         userRepository.update(user);
     }

--- a/src/main/java/io/openur/domain/user/service/oauth/KakaoService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/KakaoService.java
@@ -53,7 +53,7 @@ public class KakaoService extends LoginService {
 
         // 4. JWT 토큰 생성 및 반환
         return new GetUsersLoginDto(
-            kakaoUser.getEmail(),
+            kakaoUser.getEmail(),  // Using email as identifier for OAuth services
             kakaoUser.getNickname(),
             jwtUtil.createToken(kakaoUser.getEmail())
         );

--- a/src/main/java/io/openur/domain/user/service/oauth/LoginService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/LoginService.java
@@ -68,7 +68,7 @@ public abstract class LoginService {
     protected User registerUserIfNew(OauthUserInfoDto oauthUserInfoDto) {
         // DB 에 중복된 이메일의 유저가 있는지 확인
         String email = oauthUserInfoDto.getEmail();
-        User user = userRepository.findByEmail(email);
+        User user = userRepository.findUser(new User(email, oauthUserInfoDto.getProvider()));
         if (user == null) {
             // 없으면 회원가입
             User newUser = new User(email, oauthUserInfoDto.getProvider());
@@ -81,7 +81,7 @@ public abstract class LoginService {
     protected User registerUserIfNew(SmartWalletUserInfoDto smartWalletUserInfoDto) {
         // DB 에 중복된 블록체인 주소의 유저가 있는지 확인
         String blockchainAddress = smartWalletUserInfoDto.getBlockchainAddress();
-        User user = userRepository.findByBlockchainAddress(blockchainAddress);
+        User user = userRepository.findUser(new User(blockchainAddress));
         if (user == null) {
             // 없으면 회원가입
             User newUser = new User(blockchainAddress);

--- a/src/main/java/io/openur/domain/user/service/oauth/LoginService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/LoginService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openur.domain.user.dto.GetUsersLoginDto;
 import io.openur.domain.user.dto.OauthUserInfoDto;
+import io.openur.domain.user.dto.SmartWalletUserInfoDto;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepositoryImpl;
 import java.net.URI;
@@ -71,6 +72,19 @@ public abstract class LoginService {
         if (user == null) {
             // 없으면 회원가입
             User newUser = new User(email, oauthUserInfoDto.getProvider());
+            return userRepository.save(newUser);
+        } else {
+            return user;
+        }
+    }
+
+    protected User registerUserIfNew(SmartWalletUserInfoDto smartWalletUserInfoDto) {
+        // DB 에 중복된 블록체인 주소의 유저가 있는지 확인
+        String blockchainAddress = smartWalletUserInfoDto.getBlockchainAddress();
+        User user = userRepository.findByBlockchainAddress(blockchainAddress);
+        if (user == null) {
+            // 없으면 회원가입
+            User newUser = new User(blockchainAddress);
             return userRepository.save(newUser);
         } else {
             return user;

--- a/src/main/java/io/openur/domain/user/service/oauth/LoginServiceFactory.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/LoginServiceFactory.java
@@ -10,12 +10,14 @@ public class LoginServiceFactory {
 
     private final KakaoService kakaoService;
     private final NaverService naverService;
+    private final SmartWalletService smartWalletService;
 
     public LoginService getLoginService(Provider provider) {
         // TODO: login challenge publisher
         return switch (provider) {
             case kakao -> kakaoService;
             case naver -> naverService;
+            case smart_wallet -> smartWalletService;
             default -> throw new IllegalArgumentException("Invalid provider");
         };
     }

--- a/src/main/java/io/openur/domain/user/service/oauth/NaverService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/NaverService.java
@@ -51,7 +51,7 @@ public class NaverService extends LoginService {
 
         // 4. JWT 토큰 반환
         return new GetUsersLoginDto(
-            naverUser.getEmail(),
+            naverUser.getEmail(),  // Using email as identifier for OAuth services
             naverUser.getNickname(),
             jwtUtil.createToken(naverUser.getEmail())
         );

--- a/src/main/java/io/openur/domain/user/service/oauth/SmartWalletService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/SmartWalletService.java
@@ -5,6 +5,7 @@ import io.openur.domain.user.dto.GetUsersLoginDto;
 import io.openur.domain.user.dto.SmartWalletUserInfoDto;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepositoryImpl;
+import io.openur.global.common.validation.ValidEthereumAddress;
 import io.openur.global.jwt.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,7 @@ public class SmartWalletService extends LoginService {
     }
 
     @Override
-    public GetUsersLoginDto login(String walletAddress, String signature) throws JsonProcessingException {
+    public GetUsersLoginDto login(@ValidEthereumAddress String walletAddress, String signature) throws JsonProcessingException {
         try {
             log.info("Starting Smart Wallet login process for address: {}", walletAddress);
 

--- a/src/main/java/io/openur/domain/user/service/oauth/SmartWalletService.java
+++ b/src/main/java/io/openur/domain/user/service/oauth/SmartWalletService.java
@@ -1,0 +1,51 @@
+package io.openur.domain.user.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.openur.domain.user.dto.GetUsersLoginDto;
+import io.openur.domain.user.dto.SmartWalletUserInfoDto;
+import io.openur.domain.user.model.User;
+import io.openur.domain.user.repository.UserRepositoryImpl;
+import io.openur.global.jwt.JwtUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j(topic = "Smart Wallet Login")
+@Service
+public class SmartWalletService extends LoginService {
+    private final JwtUtil jwtUtil;
+
+    public SmartWalletService(
+        UserRepositoryImpl userRepository,
+        RestTemplate restTemplate,
+        JwtUtil jwtUtil
+    ) {
+        super(userRepository, restTemplate);
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public GetUsersLoginDto login(String walletAddress, String signature) throws JsonProcessingException {
+        try {
+            log.info("Starting Smart Wallet login process for address: {}", walletAddress);
+
+            // Find or create user
+            User user = registerUserIfNew(SmartWalletUserInfoDto.of(walletAddress));
+            log.info("User found/created successfully. User ID: {}", user.getUserId());
+
+            // Generate JWT token using wallet address
+            String token = jwtUtil.createToken(walletAddress);
+            log.debug("JWT token generated successfully");
+
+            return new GetUsersLoginDto(
+                walletAddress,  // Use wallet address as identifier
+                user.getNickname(),
+                token
+            );
+        } catch (Exception e) {
+            String errorMsg = "Failed to process smart wallet login: " + e.getMessage();
+            log.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg, e);
+        }
+    }
+} 

--- a/src/main/java/io/openur/global/common/validation/EthereumAddressValidator.java
+++ b/src/main/java/io/openur/global/common/validation/EthereumAddressValidator.java
@@ -1,0 +1,25 @@
+package io.openur.global.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class EthereumAddressValidator implements ConstraintValidator<ValidEthereumAddress, String> {
+    private static final Pattern ETH_ADDRESS_PATTERN = Pattern.compile("^0x[a-fA-F0-9]{40}$");
+    private static final int ETH_ADDRESS_LENGTH = 42; // 0x + 40 hex characters
+
+    @Override
+    public void initialize(ValidEthereumAddress constraintAnnotation) {
+        // No initialization needed
+    }
+
+    @Override
+    public boolean isValid(String address, ConstraintValidatorContext context) {
+        if (address == null || address.isEmpty()) {
+            return false;
+        }
+
+        // Check length and format
+        return address.length() == ETH_ADDRESS_LENGTH && ETH_ADDRESS_PATTERN.matcher(address).matches();
+    }
+} 

--- a/src/main/java/io/openur/global/common/validation/ValidEthereumAddress.java
+++ b/src/main/java/io/openur/global/common/validation/ValidEthereumAddress.java
@@ -1,0 +1,17 @@
+package io.openur.global.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EthereumAddressValidator.class)
+public @interface ValidEthereumAddress {
+    String message() default "Invalid Ethereum address format. Must be 42 characters long, start with '0x', and contain valid hex characters.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+} 

--- a/src/main/java/io/openur/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/io/openur/global/security/UserDetailsServiceImpl.java
@@ -15,10 +15,13 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(userEmail);
+    public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+        // Create a temporary User object with the identifier
+        // The repository will determine if it's an email or blockchain address
+        User tempUser = new User(identifier);
+        User user = userRepository.findUser(tempUser);
         if (user == null) {
-            throw new UsernameNotFoundException("Not Found " + userEmail);
+            throw new UsernameNotFoundException("Not Found " + identifier);
         }
 
         return new UserDetailsImpl(user);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,9 +3,9 @@ CREATE TABLE IF NOT EXISTS tb_users
 (
     user_id                VARCHAR(36)                      DEFAULT (UUID()) PRIMARY KEY NOT NULL,
     nickname               VARCHAR(16)                      DEFAULT NULL,
-    email                  VARCHAR(255)            NOT NULL,
+    email                  VARCHAR(255)                     DEFAULT NULL,
     identity_authenticated BOOLEAN                          DEFAULT FALSE,
-    provider               ENUM ('naver', 'kakao') NOT NULL,
+    provider               ENUM ('naver', 'kakao', 'smart_wallet') NOT NULL,
     blacklisted            BOOLEAN                          DEFAULT FALSE,
     created_date           TIMESTAMP               NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_login_date        TIMESTAMP               NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# 설명

Login step 에 Base Smart Wallet 을 추가한다. 
- Provider enum 에 `smart_wallet` 추가
- 해당하는 LoginService 기능 추가

이로 인해 email 정보 대신 blockchain address 정보만 있는 유저 데이터가 발생한다. 
- `email` nullable 반영
- 유저 정보 탐색 시 email 'OR' address 를 사용하도록 변경

연관된 이슈: BE-91

## 변경사항

커밋 순 리뷰 시 이해에 도움이 될지도

### 변경의 종류 (여러 가지 선택 가능)

- [ ] 버그 수정
- [x] 새로운 기능
- [x] 대규모 변경
- [ ] 문서 업데이트
- [ ] 기타 {{여기에 설명을 추가해 주세요}}

# Author 체크리스트

- [ ] 테스트를 통과했나요?
- [ ] 컴파일 가능한가요?
- [ ] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [ ] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [ ] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?

Enhance user login functionality by introducing Smart Wallet support, allowing users to log in using blockchain addresses. Refactor user retrieval methods for consistency and update related services and models accordingly.