### PR TITLE
fix: 보상 가능 도전과제 진행 목록 노출 복원

### DIFF
--- a/src/main/java/io/openur/domain/challenge/dto/RepetitiveChallengeTreeDto.java
+++ b/src/main/java/io/openur/domain/challenge/dto/RepetitiveChallengeTreeDto.java
@@ -22,20 +22,10 @@ public class RepetitiveChallengeTreeDto {
         Map<Long, UserChallenge> userChallengeMap, List<ChallengeStage> challengeStages
     ) {
         Challenge challenge = challengeStages.get(0).getChallenge();
-        UserChallenge currentChallenge = null;
-
-        for (ChallengeStage stage : challengeStages) {
-            UserChallenge uc = userChallengeMap.get(stage.getStageId());
-            
-            if(uc == null) continue;
-            
-            if(uc.getCompletedDate() == null) {
-                currentChallenge = uc;
-                break;
-            }
-        }
-
-        final int currCount = currentChallenge != null ? currentChallenge.getCurrentCount() : 0;
+        final int currCount = userChallengeMap.values().stream()
+            .mapToInt(UserChallenge::getCurrentCount)
+            .max()
+            .orElse(0);
 
         this.challengeTrees = challengeStages.stream().map(stage -> {
             UserChallenge uc = userChallengeMap.get(stage.getStageId());

--- a/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepository.java
+++ b/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepository.java
@@ -23,8 +23,8 @@ public interface UserChallengeRepository {
     void bulkIncrementCount(List<Long> userChallengeIds);
 
     /**
-     * Updates completion status after NFT airdrop
-     * @param completedUserChallengeIds List of challenges that have been completed and had NFT airdropped
+     * Marks challenges as achieved and ready for NFT reward issuance.
+     * @param completedUserChallengeIds List of challenges that reached their completion condition
      */
     void bulkUpdateCompletedChallenges(List<Long> completedUserChallengeIds);
 

--- a/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepositoryImpl.java
@@ -362,19 +362,63 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
 
     /**
      * "표시할 stage" 결정 규칙:
-     * (A) 해당 user의 미완료 user_challenge가 이 stage에 있으면 이 stage가 표시 대상이다, 또는
-     * (B) 해당 user가 이 challenge에 user_challenge를 하나도 가지지 않았고 (= 신규 유저),
+     * (A) 보상 수령 가능한 완료 stage가 있으면 그 stage가 표시 대상이다.
+     * (B) 보상 수령 가능한 stage가 없고, 미완료 user_challenge가 있으면 그 stage가 표시 대상이다.
+     * (C) 해당 user가 이 challenge에 user_challenge를 하나도 가지지 않았고 (= 신규 유저),
      *     이 stage가 해당 challenge의 stage_number 최소값을 가진 stage이면 표시 대상이다.
      *
      * 결과적으로 challenge 1개당 최대 1개의 stage만 통과:
      * - 신규 유저: stage 1
      * - 진행 중 유저: 진행 중인 stage
-     * - 모든 stage가 완료된 challenge: 통과 안 함 (완료 탭 영역)
+     * - 달성 후 보상 미수령 유저: 보상 수령 가능한 stage
+     * - 모든 stage가 NFT 보상까지 완료된 challenge: 통과 안 함
      */
     private BooleanExpression buildStageIsCurrentForUser(String userId) {
         QUserChallengeEntity ucSub = new QUserChallengeEntity("ucSub");
         QChallengeStageEntity stageSub = new QChallengeStageEntity("stageSub");
         QChallengeStageEntity stageMinSub = new QChallengeStageEntity("stageMinSub");
+        QUserChallengeEntity rewardableUcSub = new QUserChallengeEntity("rewardableUcSub");
+        QChallengeStageEntity rewardableStageSub = new QChallengeStageEntity("rewardableStageSub");
+        QUserChallengeEntity incompleteUcSub = new QUserChallengeEntity("incompleteUcSub");
+        QChallengeStageEntity incompleteStageSub = new QChallengeStageEntity("incompleteStageSub");
+
+        BooleanExpression hasRewardableOnThisStage = JPAExpressions
+            .selectOne()
+            .from(ucSub)
+            .where(
+                ucSub.challengeStageEntity.stageId.eq(challengeStageEntity.stageId),
+                ucSub.userEntity.userId.eq(userId),
+                ucSub.completedDate.isNotNull(),
+                ucSub.nftCompleted.isFalse()
+            )
+            .exists();
+
+        BooleanExpression hasRewardableForThisChallenge = JPAExpressions
+            .selectOne()
+            .from(rewardableUcSub)
+            .join(rewardableUcSub.challengeStageEntity, rewardableStageSub)
+            .where(
+                rewardableStageSub.challengeEntity.challengeId.eq(
+                    challengeStageEntity.challengeEntity.challengeId),
+                rewardableUcSub.userEntity.userId.eq(userId),
+                rewardableUcSub.completedDate.isNotNull(),
+                rewardableUcSub.nftCompleted.isFalse()
+            )
+            .exists();
+
+        BooleanExpression isFirstRewardableStage = challengeStageEntity.stageNumber.eq(
+            JPAExpressions
+                .select(rewardableStageSub.stageNumber.min())
+                .from(rewardableUcSub)
+                .join(rewardableUcSub.challengeStageEntity, rewardableStageSub)
+                .where(
+                    rewardableStageSub.challengeEntity.challengeId.eq(
+                        challengeStageEntity.challengeEntity.challengeId),
+                    rewardableUcSub.userEntity.userId.eq(userId),
+                    rewardableUcSub.completedDate.isNotNull(),
+                    rewardableUcSub.nftCompleted.isFalse()
+                )
+        );
 
         BooleanExpression hasIncompleteOnThisStage = JPAExpressions
             .selectOne()
@@ -385,6 +429,31 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
                 ucSub.completedDate.isNull()
             )
             .exists();
+
+        BooleanExpression hasIncompleteForThisChallenge = JPAExpressions
+            .selectOne()
+            .from(incompleteUcSub)
+            .join(incompleteUcSub.challengeStageEntity, incompleteStageSub)
+            .where(
+                incompleteStageSub.challengeEntity.challengeId.eq(
+                    challengeStageEntity.challengeEntity.challengeId),
+                incompleteUcSub.userEntity.userId.eq(userId),
+                incompleteUcSub.completedDate.isNull()
+            )
+            .exists();
+
+        BooleanExpression isFirstIncompleteStage = challengeStageEntity.stageNumber.eq(
+            JPAExpressions
+                .select(incompleteStageSub.stageNumber.min())
+                .from(incompleteUcSub)
+                .join(incompleteUcSub.challengeStageEntity, incompleteStageSub)
+                .where(
+                    incompleteStageSub.challengeEntity.challengeId.eq(
+                        challengeStageEntity.challengeEntity.challengeId),
+                    incompleteUcSub.userEntity.userId.eq(userId),
+                    incompleteUcSub.completedDate.isNull()
+                )
+        );
 
         BooleanExpression hasNoUcForThisChallenge = JPAExpressions
             .selectOne()
@@ -403,7 +472,18 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
                 .where(stageMinSub.challengeEntity.challengeId.eq(challengeStageEntity.challengeEntity.challengeId))
         );
 
-        return hasIncompleteOnThisStage.or(hasNoUcForThisChallenge.and(isMinStage));
+        return hasRewardableOnThisStage.and(isFirstRewardableStage)
+            .or(
+                hasRewardableForThisChallenge.not()
+                    .and(hasIncompleteOnThisStage)
+                    .and(isFirstIncompleteStage)
+            )
+            .or(
+                hasRewardableForThisChallenge.not()
+                    .and(hasIncompleteForThisChallenge.not())
+                    .and(hasNoUcForThisChallenge)
+                    .and(isMinStage)
+            );
     }
 
     private Map<Long, UserChallengeEntity> fetchUserChallengeMap(

--- a/src/test/java/io/openur/controller/ChallengeApiTest.java
+++ b/src/test/java/io/openur/controller/ChallengeApiTest.java
@@ -15,7 +15,9 @@ import io.openur.global.dto.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,15 +25,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeApiTest extends TestSupport {
 
     private static final String PREFIX = "/v1/challenges";
+    private static final String TEST_USER1_ID = "9e1bfc60-f76a-47dc-9147-803653707192";
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Nested
     @DisplayName("내 챌린지 목록 조회 - 조건별 테스트")
     class getMyChallengeListTest {
 
         @Test
-        @DisplayName("200 OK - 일반 챌린지 빈 결과 (challenge 1 fully completed by user1)")
-        void getGeneralChallengeList_emptyResult_isOk() throws Exception {
-            // given: user1은 normal challenge 1을 이미 완료한 상태이므로 진행 중 일반 탭은 비어 있음
+        @DisplayName("200 OK - 보상 수령 가능한 일반 챌린지는 진행 목록에 노출된다")
+        void getGeneralChallengeList_rewardableChallenge_isOk() throws Exception {
+            // given: user1은 normal challenge 1을 달성했고 아직 NFT 보상은 받지 않음
             String token = getTestUserToken1();
 
             // when
@@ -50,9 +56,13 @@ public class ChallengeApiTest extends TestSupport {
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).isEmpty();
-            assertThat(response.getTotalElements()).isEqualTo(0);
-            assertThat(response.getTotalPages()).isEqualTo(0);
+            assertThat(response.getData()).hasSize(1);
+            GeneralChallengeDto first = response.getData().get(0);
+            assertThat(first.getChallengeId()).isEqualTo(1L);
+            assertThat(first.getUserChallengeId()).isEqualTo(1L);
+            assertThat(first.getCompletedDate()).isNotNull();
+            assertThat(first.isNftCompleted()).isFalse();
+            assertThat(first.isAccomplished()).isTrue();
             assertThat(response.isFirst()).isTrue();
             assertThat(response.isLast()).isTrue();
         }
@@ -183,9 +193,9 @@ public class ChallengeApiTest extends TestSupport {
         }
 
         @Test
-        @DisplayName("200 OK - 반복 챌린지 빈 결과 (user1 has only completed/locked rows)")
-        void getRepetitiveChallengeList_emptyResult_isOk() throws Exception {
-            // given: user1은 challenge 2의 stage 2 완료, stage 3 row 없음 → 진행 중 stage 없음
+        @DisplayName("200 OK - 보상 수령 가능한 반복 챌린지는 진행 목록에 노출된다")
+        void getRepetitiveChallengeList_rewardableChallenge_isOk() throws Exception {
+            // given: user1은 challenge 2의 stage 2를 달성했고 아직 NFT 보상은 받지 않음
             String token = getTestUserToken1();
 
             // when
@@ -204,10 +214,92 @@ public class ChallengeApiTest extends TestSupport {
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).isEmpty();
-            assertThat(response.getTotalElements()).isEqualTo(0);
-            assertThat(response.getTotalPages()).isEqualTo(0);
+            assertThat(response.getData()).hasSize(1);
+            GeneralChallengeDto first = response.getData().get(0);
+            assertThat(first.getChallengeId()).isEqualTo(2L);
+            assertThat(first.getUserChallengeId()).isEqualTo(2L);
+            assertThat(first.getCompletedDate()).isNotNull();
+            assertThat(first.isNftCompleted()).isFalse();
+            assertThat(first.isAccomplished()).isTrue();
             assertThat(response.getMessage()).isEqualTo("success");
+        }
+
+        @Test
+        @DisplayName("200 OK - NFT 보상까지 완료한 도전과제는 진행 목록에서 제외된다")
+        void getChallengeLists_nftCompletedChallenge_isHidden() throws Exception {
+            // given
+            jdbcTemplate.update(
+                "UPDATE tb_users_challenges SET nft_completed = TRUE WHERE user_challenge_id IN (1, 2)");
+            String token = getTestUserToken1();
+
+            // when
+            MvcResult generalResult = mockMvc.perform(
+                get(PREFIX + "/general")
+                    .header(AUTH_HEADER, token)
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+            MvcResult repetitiveResult = mockMvc.perform(
+                get(PREFIX + "/repetitive")
+                    .header(AUTH_HEADER, token)
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+
+            // then
+            PagedResponse<GeneralChallengeDto> generalResponse = parseResponse(
+                generalResult.getResponse().getContentAsString(),
+                new TypeReference<>() {}
+            );
+            PagedResponse<GeneralChallengeDto> repetitiveResponse = parseResponse(
+                repetitiveResult.getResponse().getContentAsString(),
+                new TypeReference<>() {}
+            );
+
+            assertThat(generalResponse.getData()).isEmpty();
+            assertThat(repetitiveResponse.getData()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("200 OK - 보상 수령 가능 stage는 다음 진행 stage보다 우선 노출된다")
+        void getRepetitiveChallengeList_rewardableStage_hasPriority() throws Exception {
+            // given: stage 2는 보상 수령 가능, stage 3은 다음 진행 stage
+            jdbcTemplate.update(
+                """
+                    INSERT INTO tb_users_challenges
+                        (user_challenge_id, user_id, challenge_stage_id, current_count,
+                         current_progress, nft_completed, completed_date)
+                    VALUES
+                        (10, ?, 4, 3, 60.0, FALSE, NULL)
+                    """,
+                TEST_USER1_ID
+            );
+            String token = getTestUserToken1();
+
+            // when
+            MvcResult result = mockMvc.perform(
+                get(PREFIX + "/repetitive")
+                    .header(AUTH_HEADER, token)
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+
+            // then
+            PagedResponse<GeneralChallengeDto> response = parseResponse(
+                result.getResponse().getContentAsString(),
+                new TypeReference<>() {}
+            );
+
+            assertThat(response.getData()).hasSize(1);
+            GeneralChallengeDto first = response.getData().get(0);
+            assertThat(first.getChallengeId()).isEqualTo(2L);
+            assertThat(first.getUserChallengeId()).isEqualTo(2L);
+            assertThat(first.getStageCount()).isEqualTo(2);
+            assertThat(first.getCompletedDate()).isNotNull();
+            assertThat(first.isNftCompleted()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
- completed_date와 nft_completed를 분리해 보상 미수령 완료 도전과제를 /general, /repetitive에 노출
- 반복 도전과제에서 보상 가능 stage를 진행 중 stage보다 우선 노출
- nft_completed=true 도전과제는 진행 목록에서 제외되도록 테스트 보강

# 설명

{{replace this}}

연관된 이슈: #{{이슈 번호}}

## 변경사항

{{replace this}}

### 변경의 종류 (여러 가지 선택 가능)

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 대규모 변경
- [ ] 문서 업데이트
- [ ] 기타 {{여기에 설명을 추가해 주세요}}

# Author 체크리스트

- [ ] 테스트를 통과했나요?
- [ ] 컴파일 가능한가요?
- [ ] PR 하기 전에 코드를 다시 한번 살펴보셨나요?
- [ ] 이해하기 힘든 부분에 주석을 달아 두셨나요?
- [ ] 바뀐 부분에 대해 문서화도 새로 하셨나요? (머지 하면서 컨플 API 문서에 반영하기)
- [ ] PR이 새로운 컴파일 경고를 추가하는지 확인하셨나요?
- [ ] 변경사항을 검증할 수 있는 테스트를 추가하고 실행하셨나요?

# Reviewer 체크리스트

- [ ] 주석화 된 Code는 주석화 된 이유에 대해서 명시되어 있는가?
- [ ] 함수의 Parameter는 유효한 값을 가지고 있는가?
- [ ] 사용되는 변수들은 상황에 맞게 적절하게 선언되어 있는가?
- [ ] 변수들이 사용되기 전에 초기화되어 있는가?
- [ ] 계산에 사용되는 변수의 Data Type이 올바른가?
- [ ] 예외 처리가 잘 되어 있는가?
- [ ] 코드가 무한 루프에 빠지는 상황은 없는가?
- [ ] 발견된 버그는 모두 올바르게 수정되었는가?
