### PR TITLE
[codex] 프로필 요약 API 추가

### DIFF
--- a/src/main/java/io/openur/domain/NFT/repository/NftMintJobJpaRepository.java
+++ b/src/main/java/io/openur/domain/NFT/repository/NftMintJobJpaRepository.java
@@ -24,6 +24,17 @@ public interface NftMintJobJpaRepository extends JpaRepository<NftMintJobEntity,
     List<NftMintJobEntity> findByUserChallengeEntityUserChallengeIdInAndStatus(
         Collection<Long> userChallengeIds, NftMintJobStatus status);
 
+    long countByUserEntityUserIdAndStatusAndUserChallengeEntityCompletedDateIsNotNullAndUserChallengeEntityNftCompletedTrue(
+        String userId, NftMintJobStatus status);
+
+    @EntityGraph(attributePaths = {
+        "userChallengeEntity",
+        "userChallengeEntity.challengeStageEntity",
+        "userChallengeEntity.challengeStageEntity.challengeEntity"
+    })
+    List<NftMintJobEntity> findTop3ByUserEntityUserIdAndStatusAndUserChallengeEntityCompletedDateIsNotNullAndUserChallengeEntityNftCompletedTrueOrderByUpdatedAtDescMintJobIdDesc(
+        String userId, NftMintJobStatus status);
+
     Slice<NftMintJobEntity> findByStatusAndUpdatedAtBefore(
         NftMintJobStatus status, LocalDateTime cutoff, Pageable pageable);
 }

--- a/src/main/java/io/openur/domain/user/controller/UserController.java
+++ b/src/main/java/io/openur/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.domain.user.dto.GetUsersLoginDto;
 import io.openur.domain.user.dto.GetUsersResponseDto;
 import io.openur.domain.user.dto.PatchUserSurveyRequestDto;
+import io.openur.domain.user.dto.ProfileSummaryResponseDto;
 import io.openur.domain.user.exception.UserNotFoundException;
 import io.openur.domain.user.model.Provider;
 import io.openur.domain.user.service.UserService;
@@ -78,6 +79,19 @@ public class UserController {
             .body(Response.<GetUserResponseDto>builder()
                 .message("success")
                 .data(getUserResponseDto)
+                .build());
+    }
+
+    @GetMapping("/profile-summary")
+    @Operation(summary = "프로필 요약 정보 가져오기")
+    public ResponseEntity<Response<ProfileSummaryResponseDto>> getProfileSummary(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ProfileSummaryResponseDto profileSummary = userService.getProfileSummary(userDetails);
+        return ResponseEntity.ok()
+            .body(Response.<ProfileSummaryResponseDto>builder()
+                .message("success")
+                .data(profileSummary)
                 .build());
     }
 

--- a/src/main/java/io/openur/domain/user/dto/ProfileSummaryResponseDto.java
+++ b/src/main/java/io/openur/domain/user/dto/ProfileSummaryResponseDto.java
@@ -1,0 +1,74 @@
+package io.openur.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.openur.domain.NFT.entity.NftMintJobEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ProfileSummaryResponseDto {
+
+    private final long receivedLikeCount;
+    private final long currentOwnedBungCount;
+    private final long acquiredNftCount;
+    private final List<RecentAcquiredNftDto> recentAcquiredNfts;
+
+    public ProfileSummaryResponseDto(
+        long receivedLikeCount,
+        long currentOwnedBungCount,
+        long acquiredNftCount,
+        List<NftMintJobEntity> recentAcquiredNftJobs
+    ) {
+        this.receivedLikeCount = receivedLikeCount;
+        this.currentOwnedBungCount = currentOwnedBungCount;
+        this.acquiredNftCount = acquiredNftCount;
+        this.recentAcquiredNfts = recentAcquiredNftJobs.stream()
+            .map(RecentAcquiredNftDto::new)
+            .toList();
+    }
+
+    @Getter
+    public static class RecentAcquiredNftDto {
+        private final Long userChallengeId;
+        private final Long challengeId;
+        private final String challengeName;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private final LocalDateTime acquiredAt;
+        private final NftInfoDto nft;
+
+        private RecentAcquiredNftDto(NftMintJobEntity mintJob) {
+            var userChallenge = mintJob.getUserChallengeEntity();
+            var challenge = userChallenge
+                .getChallengeStageEntity()
+                .getChallengeEntity();
+
+            this.userChallengeId = userChallenge.getUserChallengeId();
+            this.challengeId = challenge.getChallengeId();
+            this.challengeName = challenge.getName();
+            this.acquiredAt = mintJob.getUpdatedAt();
+            this.nft = new NftInfoDto(mintJob);
+        }
+    }
+
+    @Getter
+    public static class NftInfoDto {
+        private final String tokenId;
+        private final String transactionHash;
+        private final String name;
+        private final String description;
+        private final String image;
+        private final String category;
+        private final String rarity;
+
+        private NftInfoDto(NftMintJobEntity mintJob) {
+            this.tokenId = mintJob.getTokenId();
+            this.transactionHash = mintJob.getTransactionHash();
+            this.name = mintJob.getNftName();
+            this.description = mintJob.getNftDescription();
+            this.image = mintJob.getNftImage();
+            this.category = mintJob.getNftCategory();
+            this.rarity = mintJob.getNftRarity();
+        }
+    }
+}

--- a/src/main/java/io/openur/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepository.java
@@ -13,6 +13,8 @@ public interface UserRepository {
 
     User findById(String userId);
 
+    long findFeedbackCountByUserId(String userId);
+
     List<User> findByUserNickname(String nickName);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
@@ -51,6 +51,16 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public long findFeedbackCountByUserId(String userId) {
+        Integer feedback = queryFactory
+            .select(userEntity.feedback)
+            .from(userEntity)
+            .where(userEntity.userId.eq(userId))
+            .fetchOne();
+        return feedback == null ? 0L : feedback.longValue();
+    }
+
+    @Override
     public List<User> findByUserNickname(String nickname) {
         List<UserEntity> userEntity = userJpaRepository.findAllByNicknameContains(nickname);
         return userEntity.stream().map(User::from).toList();

--- a/src/main/java/io/openur/domain/user/service/UserService.java
+++ b/src/main/java/io/openur/domain/user/service/UserService.java
@@ -1,8 +1,12 @@
 package io.openur.domain.user.service;
 
+import io.openur.domain.NFT.entity.NftMintJobEntity;
+import io.openur.domain.NFT.enums.NftMintJobStatus;
+import io.openur.domain.NFT.repository.NftMintJobJpaRepository;
 import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.domain.user.dto.GetUsersResponseDto;
 import io.openur.domain.user.dto.PatchUserSurveyRequestDto;
+import io.openur.domain.user.dto.ProfileSummaryResponseDto;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepository;
 import io.openur.domain.userbung.repository.UserBungRepository;
@@ -24,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserBungRepository userBungRepository;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
+    private final NftMintJobJpaRepository nftMintJobJpaRepository;
 
     public String getUserById(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userRepository.findUser(userDetails.getUser());
@@ -37,6 +42,31 @@ public class UserService {
     public GetUserResponseDto getUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userRepository.findUser(userDetails.getUser());
         return new GetUserResponseDto(user, userProfileImageUrlResolver.resolve(user.getProfileImageStorageKey()));
+    }
+
+    public ProfileSummaryResponseDto getProfileSummary(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User user = userRepository.findUser(userDetails.getUser());
+        String userId = user.getUserId();
+
+        long receivedLikeCount = userRepository.findFeedbackCountByUserId(userId);
+        long currentOwnedBungCount = userBungRepository.countCurrentOwnedBungsByUserId(userId);
+        long acquiredNftCount = nftMintJobJpaRepository
+            .countByUserEntityUserIdAndStatusAndUserChallengeEntityCompletedDateIsNotNullAndUserChallengeEntityNftCompletedTrue(
+                userId,
+                NftMintJobStatus.SUCCESS
+            );
+        List<NftMintJobEntity> recentAcquiredNfts = nftMintJobJpaRepository
+            .findTop3ByUserEntityUserIdAndStatusAndUserChallengeEntityCompletedDateIsNotNullAndUserChallengeEntityNftCompletedTrueOrderByUpdatedAtDescMintJobIdDesc(
+                userId,
+                NftMintJobStatus.SUCCESS
+            );
+
+        return new ProfileSummaryResponseDto(
+            receivedLikeCount,
+            currentOwnedBungCount,
+            acquiredNftCount,
+            recentAcquiredNfts
+        );
     }
 
     public List<GetUserResponseDto> searchByNickname(String nickname) {

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -14,6 +14,8 @@ public interface UserBungRepository {
 
     int countParticipantsByBungId(String bungId);
 
+    long countCurrentOwnedBungsByUserId(String userId);
+
     Optional<BungInfoWithMemberListDto> findBungWithUsersById(String bungId);
 
     Page<Tuple> findAllFrequentUsers(List<String> bungIds, User user, Pageable pageable);

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -52,6 +52,20 @@ public class UserBungRepositoryImpl implements UserBungRepository {
     }
 
     @Override
+    public long countCurrentOwnedBungsByUserId(String userId) {
+        Long count = queryFactory
+            .select(userBungEntity.bungEntity.bungId.countDistinct())
+            .from(userBungEntity)
+            .join(userBungEntity.bungEntity, bungEntity)
+            .where(
+                userBungEntity.userEntity.userId.eq(userId),
+                userBungEntity.isOwner.isTrue()
+            )
+            .fetchOne();
+        return count == null ? 0L : count;
+    }
+
+    @Override
     public Optional<BungInfoWithMemberListDto> findBungWithUsersById(String bungId) {
         List<UserBungEntity> members = queryFactory
             .selectFrom(userBungEntity)

--- a/src/test/java/io/openur/controller/UserApiTest.java
+++ b/src/test/java/io/openur/controller/UserApiTest.java
@@ -2,13 +2,18 @@ package io.openur.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.openur.config.TestSupport;
 import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.global.dto.Response;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +51,53 @@ public class UserApiTest extends TestSupport {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.profileImageUrl").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    @DisplayName("프로필 요약")
+    void getProfileSummaryTest() throws Exception {
+        when(nftMintClient.mintToken(any(String.class), any(BigInteger.class), any(BigInteger.class)))
+            .thenReturn("0xtxhash");
+
+        mockMvc.perform(
+            post("/v1/nft/mint-jobs")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .param("userChallengeId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        mockMvc.perform(
+            post("/v1/nft/mint-jobs")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .param("userChallengeId", "2")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", "c0477004-1632-455f-acc9-04584b55921f");
+        feedbackRequest.put("targetUserIds", List.of("9e1bfc60-f76a-47dc-9147-803653707192"));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isOk());
+
+        mockMvc.perform(
+            get(PREFIX + "/profile-summary")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("success"))
+            .andExpect(jsonPath("$.data.receivedLikeCount").value(1))
+            .andExpect(jsonPath("$.data.currentOwnedBungCount").value(1))
+            .andExpect(jsonPath("$.data.acquiredNftCount").value(2))
+            .andExpect(jsonPath("$.data.recentAcquiredNfts", hasSize(2)))
+            .andExpect(jsonPath("$.data.recentAcquiredNfts[0].challengeName").exists())
+            .andExpect(jsonPath("$.data.recentAcquiredNfts[0].acquiredAt").exists())
+            .andExpect(jsonPath("$.data.recentAcquiredNfts[0].nft.transactionHash").value("0xtxhash"));
     }
 
     @Nested


### PR DESCRIPTION
## 변경 사항
- `GET /v1/users/profile-summary` 엔드포인트 추가
- 받은 좋아요, 현재 개설한 벙, 획득한 NFT 수 집계 추가
- 최근 획득 NFT 3건 응답 DTO 추가
- 프로필 요약 API 컨트롤러 테스트 추가

## 영향
- 프론트 홈/프로필 화면에서 필요한 요약 수치를 한 번에 조회할 수 있습니다.
- 최근 획득 NFT는 성공한 민팅 잡과 완료된 user challenge 기준으로 내려갑니다.

## 검증
- `./gradlew test --tests io.openur.controller.UserApiTest`
- `git diff --check`