### PR TITLE
[codex] refresh token 세션 관리 추가

### DIFF
--- a/src/main/java/io/openur/domain/user/controller/AuthController.java
+++ b/src/main/java/io/openur/domain/user/controller/AuthController.java
@@ -1,0 +1,75 @@
+package io.openur.domain.user.controller;
+
+import static io.openur.domain.user.service.RefreshTokenCookieFactory.REFRESH_TOKEN_COOKIE_NAME;
+
+import io.openur.domain.user.dto.LoginNonceRequestDto;
+import io.openur.domain.user.dto.LoginNonceResponseDto;
+import io.openur.domain.user.dto.RefreshTokenResponseDto;
+import io.openur.domain.user.service.LoginNonceService;
+import io.openur.domain.user.service.RefreshTokenCookieFactory;
+import io.openur.domain.user.service.RefreshTokenService;
+import io.openur.global.dto.Response;
+import io.openur.global.jwt.InvalidJwtException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenCookieFactory refreshTokenCookieFactory;
+    private final LoginNonceService loginNonceService;
+
+    @PostMapping("/login-nonce")
+    public ResponseEntity<Response<LoginNonceResponseDto>> issueLoginNonce(
+        @RequestBody @Valid LoginNonceRequestDto request
+    ) {
+        return ResponseEntity.ok()
+            .body(Response.<LoginNonceResponseDto>builder()
+                .message("success")
+                .data(loginNonceService.issue(request.getBlockchainAddress()))
+                .build());
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Response<RefreshTokenResponseDto>> refresh(
+        @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken
+    ) {
+        if (!StringUtils.hasText(refreshToken)) {
+            throw new InvalidJwtException("Missing refresh token");
+        }
+
+        RefreshTokenService.SessionTokens sessionTokens = refreshTokenService.rotate(refreshToken);
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.create(sessionTokens.refreshToken()).toString())
+            .body(Response.<RefreshTokenResponseDto>builder()
+                .message("success")
+                .data(new RefreshTokenResponseDto(sessionTokens.jwtToken()))
+                .build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Response<Void>> logout(
+        @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken
+    ) {
+        if (StringUtils.hasText(refreshToken)) {
+            refreshTokenService.revoke(refreshToken);
+        }
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.clear().toString())
+            .body(Response.<Void>builder()
+                .message("success")
+                .build());
+    }
+}

--- a/src/main/java/io/openur/domain/user/controller/UserController.java
+++ b/src/main/java/io/openur/domain/user/controller/UserController.java
@@ -7,8 +7,11 @@ import io.openur.domain.user.dto.GetUsersLoginDto;
 import io.openur.domain.user.dto.GetUsersResponseDto;
 import io.openur.domain.user.dto.PatchUserSurveyRequestDto;
 import io.openur.domain.user.dto.ProfileSummaryResponseDto;
+import io.openur.domain.user.dto.SmartWalletLoginRequestDto;
 import io.openur.domain.user.exception.UserNotFoundException;
 import io.openur.domain.user.model.Provider;
+import io.openur.domain.user.service.RefreshTokenCookieFactory;
+import io.openur.domain.user.service.RefreshTokenService;
 import io.openur.domain.user.service.UserService;
 import io.openur.domain.user.service.login.LoginService;
 import io.openur.domain.user.service.login.LoginServiceFactory;
@@ -27,15 +30,17 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -48,21 +53,30 @@ public class UserController {
 
     private final LoginServiceFactory loginServiceFactory;
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenCookieFactory refreshTokenCookieFactory;
 
-    @GetMapping("/login/{authServer}")
+    @PostMapping("/login/{authServer}")
     @Operation(summary = "유저 로그인 성공 시 정보 반환")
     public ResponseEntity<Response<GetUsersLoginDto>> getUser(
         @PathVariable Provider authServer,
-        @RequestParam String code,
-        @RequestParam(required = false) String state
+        @RequestBody @Valid SmartWalletLoginRequestDto smartWalletLoginRequestDto
     ) {
         LoginService loginService = loginServiceFactory.getLoginService(
             authServer);
         try {
+            GetUsersLoginDto loginResponse = loginService.login(
+                smartWalletLoginRequestDto.getCode(),
+                smartWalletLoginRequestDto.getState(),
+                smartWalletLoginRequestDto.getNonce()
+            );
+            String refreshToken = refreshTokenService.issueRefreshToken(loginResponse.getIdentifier());
+
             return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.create(refreshToken).toString())
                 .body(Response.<GetUsersLoginDto>builder()
                     .message("success")
-                    .data(loginService.login(code, state))
+                    .data(loginResponse)
                     .build());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/io/openur/domain/user/dto/LoginNonceRequestDto.java
+++ b/src/main/java/io/openur/domain/user/dto/LoginNonceRequestDto.java
@@ -1,0 +1,15 @@
+package io.openur.domain.user.dto;
+
+import io.openur.global.common.validation.ValidEthereumAddress;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginNonceRequestDto {
+
+    @NotBlank
+    @ValidEthereumAddress
+    private String blockchainAddress;
+}

--- a/src/main/java/io/openur/domain/user/dto/LoginNonceResponseDto.java
+++ b/src/main/java/io/openur/domain/user/dto/LoginNonceResponseDto.java
@@ -1,0 +1,11 @@
+package io.openur.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginNonceResponseDto {
+    private final String nonce;
+    private final String message;
+}

--- a/src/main/java/io/openur/domain/user/dto/RefreshTokenResponseDto.java
+++ b/src/main/java/io/openur/domain/user/dto/RefreshTokenResponseDto.java
@@ -1,0 +1,10 @@
+package io.openur.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenResponseDto {
+    private final String jwtToken;
+}

--- a/src/main/java/io/openur/domain/user/dto/SmartWalletLoginRequestDto.java
+++ b/src/main/java/io/openur/domain/user/dto/SmartWalletLoginRequestDto.java
@@ -1,0 +1,21 @@
+package io.openur.domain.user.dto;
+
+import io.openur.global.common.validation.ValidEthereumAddress;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SmartWalletLoginRequestDto {
+
+    @NotBlank
+    @ValidEthereumAddress
+    private String code;
+
+    @NotBlank
+    private String nonce;
+
+    @NotBlank
+    private String state;
+}

--- a/src/main/java/io/openur/domain/user/entity/LoginNonceEntity.java
+++ b/src/main/java/io/openur/domain/user/entity/LoginNonceEntity.java
@@ -1,0 +1,86 @@
+package io.openur.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+    name = "tb_login_nonces",
+    indexes = {
+        @Index(name = "idx_login_nonce_nonce", columnList = "nonce", unique = true),
+        @Index(name = "idx_login_nonce_blockchain_address", columnList = "blockchain_address")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginNonceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "login_nonce_id")
+    private String loginNonceId;
+
+    @Column(nullable = false, unique = true, length = 96)
+    private String nonce;
+
+    @Column(name = "blockchain_address", nullable = false, length = 42)
+    private String blockchainAddress;
+
+    @Column(nullable = false, length = 512)
+    private String message;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private Boolean used;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    private LoginNonceEntity(
+        String nonce,
+        String blockchainAddress,
+        String message,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+    ) {
+        this.nonce = nonce;
+        this.blockchainAddress = blockchainAddress;
+        this.message = message;
+        this.expiresAt = expiresAt;
+        this.used = false;
+        this.createdAt = createdAt;
+    }
+
+    public static LoginNonceEntity issue(
+        String nonce,
+        String blockchainAddress,
+        String message,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+    ) {
+        return new LoginNonceEntity(nonce, blockchainAddress, message, expiresAt, createdAt);
+    }
+
+    public boolean isUsable(LocalDateTime now) {
+        return !Boolean.TRUE.equals(used) && expiresAt.isAfter(now);
+    }
+
+    public void markUsed(LocalDateTime now) {
+        this.used = true;
+        this.usedAt = now;
+    }
+}

--- a/src/main/java/io/openur/domain/user/entity/RefreshTokenEntity.java
+++ b/src/main/java/io/openur/domain/user/entity/RefreshTokenEntity.java
@@ -1,0 +1,80 @@
+package io.openur.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+    name = "tb_refresh_tokens",
+    indexes = {
+        @Index(name = "idx_refresh_token_hash", columnList = "token_hash", unique = true),
+        @Index(name = "idx_refresh_token_blockchain_address", columnList = "blockchain_address")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "refresh_token_id")
+    private String refreshTokenId;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Column(name = "blockchain_address", nullable = false, length = 42)
+    private String blockchainAddress;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private Boolean revoked;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    private RefreshTokenEntity(
+        String tokenHash,
+        String blockchainAddress,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+    ) {
+        this.tokenHash = tokenHash;
+        this.blockchainAddress = blockchainAddress;
+        this.expiresAt = expiresAt;
+        this.revoked = false;
+        this.createdAt = createdAt;
+    }
+
+    public static RefreshTokenEntity issue(
+        String tokenHash,
+        String blockchainAddress,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+    ) {
+        return new RefreshTokenEntity(tokenHash, blockchainAddress, expiresAt, createdAt);
+    }
+
+    public boolean isUsable(LocalDateTime now) {
+        return !Boolean.TRUE.equals(revoked) && expiresAt.isAfter(now);
+    }
+
+    public void revoke(LocalDateTime now) {
+        this.revoked = true;
+        this.revokedAt = now;
+    }
+}

--- a/src/main/java/io/openur/domain/user/repository/LoginNonceJpaRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/LoginNonceJpaRepository.java
@@ -1,0 +1,16 @@
+package io.openur.domain.user.repository;
+
+import io.openur.domain.user.entity.LoginNonceEntity;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LoginNonceJpaRepository extends JpaRepository<LoginNonceEntity, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select n from LoginNonceEntity n where n.nonce = :nonce")
+    Optional<LoginNonceEntity> findByNonceForUpdate(@Param("nonce") String nonce);
+}

--- a/src/main/java/io/openur/domain/user/repository/RefreshTokenJpaRepository.java
+++ b/src/main/java/io/openur/domain/user/repository/RefreshTokenJpaRepository.java
@@ -1,0 +1,30 @@
+package io.openur.domain.user.repository;
+
+import io.openur.domain.user.entity.RefreshTokenEntity;
+import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from RefreshTokenEntity r where r.tokenHash = :tokenHash")
+    Optional<RefreshTokenEntity> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update RefreshTokenEntity r
+        set r.revoked = true, r.revokedAt = :revokedAt
+        where lower(r.blockchainAddress) = lower(:blockchainAddress)
+          and r.revoked = false
+        """)
+    int revokeActiveTokensByBlockchainAddress(
+        @Param("blockchainAddress") String blockchainAddress,
+        @Param("revokedAt") LocalDateTime revokedAt
+    );
+}

--- a/src/main/java/io/openur/domain/user/service/LoginMessageFactory.java
+++ b/src/main/java/io/openur/domain/user/service/LoginMessageFactory.java
@@ -1,0 +1,23 @@
+package io.openur.domain.user.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginMessageFactory {
+
+    public String create(String blockchainAddress, String nonce, LocalDateTime expiresAt) {
+        return """
+            OpenRun login
+
+            Wallet: %s
+            Nonce: %s
+            Expires At: %s
+            """.formatted(
+            blockchainAddress,
+            nonce,
+            expiresAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        ).trim();
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/LoginNonceService.java
+++ b/src/main/java/io/openur/domain/user/service/LoginNonceService.java
@@ -1,0 +1,60 @@
+package io.openur.domain.user.service;
+
+import io.openur.domain.user.dto.LoginNonceResponseDto;
+import io.openur.domain.user.entity.LoginNonceEntity;
+import io.openur.domain.user.repository.LoginNonceJpaRepository;
+import io.openur.global.jwt.InvalidJwtException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LoginNonceService {
+
+    private static final int NONCE_BYTE_LENGTH = 32;
+    private static final String INVALID_LOGIN_PROOF_MESSAGE = "Invalid wallet login proof";
+
+    private final LoginNonceJpaRepository loginNonceJpaRepository;
+    private final SmartWalletSignatureVerifier signatureVerifier;
+    private final SecureTokenGenerator secureTokenGenerator;
+    private final LoginMessageFactory loginMessageFactory;
+
+    @Value("${openrun.auth.login-nonce.max-age-seconds:300}")
+    private long loginNonceMaxAgeSeconds;
+
+    @Transactional
+    public LoginNonceResponseDto issue(String blockchainAddress) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusSeconds(loginNonceMaxAgeSeconds);
+        String nonce = secureTokenGenerator.generateUrlSafeToken(NONCE_BYTE_LENGTH);
+        String message = loginMessageFactory.create(blockchainAddress, nonce, expiresAt);
+
+        loginNonceJpaRepository.save(LoginNonceEntity.issue(
+            nonce,
+            blockchainAddress,
+            message,
+            expiresAt,
+            now
+        ));
+
+        return new LoginNonceResponseDto(nonce, message);
+    }
+
+    @Transactional
+    public void consume(String blockchainAddress, String nonce, String signature) {
+        LocalDateTime now = LocalDateTime.now();
+        LoginNonceEntity loginNonceEntity = loginNonceJpaRepository.findByNonceForUpdate(nonce)
+            .orElseThrow(() -> new InvalidJwtException(INVALID_LOGIN_PROOF_MESSAGE));
+
+        if (!loginNonceEntity.isUsable(now)
+            || !loginNonceEntity.getBlockchainAddress().equalsIgnoreCase(blockchainAddress)
+            || !signatureVerifier.verify(blockchainAddress, loginNonceEntity.getMessage(), signature)) {
+            throw new InvalidJwtException(INVALID_LOGIN_PROOF_MESSAGE);
+        }
+
+        loginNonceEntity.markUsed(now);
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/RefreshTokenCookieFactory.java
+++ b/src/main/java/io/openur/domain/user/service/RefreshTokenCookieFactory.java
@@ -1,0 +1,42 @@
+package io.openur.domain.user.service;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenCookieFactory {
+
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "OPENRUN_REFRESH_TOKEN";
+    private static final String REFRESH_TOKEN_COOKIE_PATH = "/v1/auth";
+
+    @Value("${openrun.auth.refresh-token.max-age-seconds:2592000}")
+    private long refreshTokenMaxAgeSeconds;
+
+    @Value("${openrun.auth.refresh-token.cookie-secure:true}")
+    private boolean cookieSecure;
+
+    @Value("${openrun.auth.refresh-token.cookie-same-site:None}")
+    private String cookieSameSite;
+
+    public ResponseCookie create(String refreshToken) {
+        return baseCookie(refreshToken)
+            .maxAge(Duration.ofSeconds(refreshTokenMaxAgeSeconds))
+            .build();
+    }
+
+    public ResponseCookie clear() {
+        return baseCookie("")
+            .maxAge(Duration.ZERO)
+            .build();
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseCookie(String value) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, value)
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite(cookieSameSite)
+            .path(REFRESH_TOKEN_COOKIE_PATH);
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/RefreshTokenService.java
+++ b/src/main/java/io/openur/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,92 @@
+package io.openur.domain.user.service;
+
+import io.openur.domain.user.entity.RefreshTokenEntity;
+import io.openur.domain.user.repository.RefreshTokenJpaRepository;
+import io.openur.domain.user.repository.UserJpaRepository;
+import io.openur.global.jwt.InvalidJwtException;
+import io.openur.global.jwt.JwtUtil;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final int TOKEN_BYTE_LENGTH = 64;
+    private static final String INVALID_REFRESH_TOKEN_MESSAGE = "Invalid refresh token";
+
+    private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final JwtUtil jwtUtil;
+    private final SecureTokenGenerator secureTokenGenerator;
+    private final TokenHashService tokenHashService;
+
+    @Value("${openrun.auth.refresh-token.max-age-seconds:2592000}")
+    private long refreshTokenMaxAgeSeconds;
+
+    @Transactional
+    public String issueRefreshToken(String blockchainAddress) {
+        String refreshToken = secureTokenGenerator.generateUrlSafeToken(TOKEN_BYTE_LENGTH);
+        saveRefreshToken(refreshToken, blockchainAddress, LocalDateTime.now());
+        return refreshToken;
+    }
+
+    @Transactional
+    public SessionTokens rotate(String refreshToken) {
+        LocalDateTime now = LocalDateTime.now();
+        RefreshTokenEntity refreshTokenEntity = findUsableRefreshToken(refreshToken, now);
+        String blockchainAddress = refreshTokenEntity.getBlockchainAddress();
+
+        if (userJpaRepository.findByBlockchainAddress(blockchainAddress).isEmpty()) {
+            refreshTokenEntity.revoke(now);
+            throw new InvalidJwtException(INVALID_REFRESH_TOKEN_MESSAGE);
+        }
+
+        refreshTokenEntity.revoke(now);
+
+        String newRefreshToken = secureTokenGenerator.generateUrlSafeToken(TOKEN_BYTE_LENGTH);
+        saveRefreshToken(newRefreshToken, blockchainAddress, now);
+
+        return new SessionTokens(jwtUtil.createToken(blockchainAddress), newRefreshToken);
+    }
+
+    @Transactional
+    public void revoke(String refreshToken) {
+        String tokenHash = tokenHashService.sha256(refreshToken);
+        LocalDateTime now = LocalDateTime.now();
+        refreshTokenJpaRepository.findByTokenHashForUpdate(tokenHash)
+            .ifPresent(refreshTokenEntity ->
+                refreshTokenJpaRepository.revokeActiveTokensByBlockchainAddress(
+                    refreshTokenEntity.getBlockchainAddress(),
+                    now
+                )
+            );
+    }
+
+    private RefreshTokenEntity findUsableRefreshToken(String refreshToken, LocalDateTime now) {
+        String tokenHash = tokenHashService.sha256(refreshToken);
+        RefreshTokenEntity refreshTokenEntity = refreshTokenJpaRepository.findByTokenHashForUpdate(tokenHash)
+            .orElseThrow(() -> new InvalidJwtException(INVALID_REFRESH_TOKEN_MESSAGE));
+
+        if (!refreshTokenEntity.isUsable(now)) {
+            throw new InvalidJwtException(INVALID_REFRESH_TOKEN_MESSAGE);
+        }
+
+        return refreshTokenEntity;
+    }
+
+    private void saveRefreshToken(String refreshToken, String blockchainAddress, LocalDateTime now) {
+        refreshTokenJpaRepository.save(RefreshTokenEntity.issue(
+            tokenHashService.sha256(refreshToken),
+            blockchainAddress,
+            now.plusSeconds(refreshTokenMaxAgeSeconds),
+            now
+        ));
+    }
+
+    public record SessionTokens(String jwtToken, String refreshToken) {
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/SecureTokenGenerator.java
+++ b/src/main/java/io/openur/domain/user/service/SecureTokenGenerator.java
@@ -1,0 +1,17 @@
+package io.openur.domain.user.service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecureTokenGenerator {
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generateUrlSafeToken(int byteLength) {
+        byte[] bytes = new byte[byteLength];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/SmartWalletSignatureVerifier.java
+++ b/src/main/java/io/openur/domain/user/service/SmartWalletSignatureVerifier.java
@@ -1,0 +1,43 @@
+package io.openur.domain.user.service;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.SignatureException;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.Sign;
+import org.web3j.utils.Numeric;
+
+@Component
+public class SmartWalletSignatureVerifier {
+
+    private static final int SIGNATURE_BYTE_LENGTH = 65;
+
+    public boolean verify(String walletAddress, String message, String signature) {
+        try {
+            byte[] signatureBytes = Numeric.hexStringToByteArray(signature);
+            if (signatureBytes.length != SIGNATURE_BYTE_LENGTH) {
+                return false;
+            }
+
+            byte v = signatureBytes[64];
+            if (v < 27) {
+                v += 27;
+            }
+
+            byte[] r = Arrays.copyOfRange(signatureBytes, 0, 32);
+            byte[] s = Arrays.copyOfRange(signatureBytes, 32, 64);
+            Sign.SignatureData signatureData = new Sign.SignatureData(v, r, s);
+            BigInteger publicKey = Sign.signedPrefixedMessageToKey(
+                message.getBytes(StandardCharsets.UTF_8),
+                signatureData
+            );
+            String recoveredAddress = "0x" + Keys.getAddress(publicKey);
+
+            return recoveredAddress.equalsIgnoreCase(walletAddress);
+        } catch (IllegalArgumentException | SignatureException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/TokenHashService.java
+++ b/src/main/java/io/openur/domain/user/service/TokenHashService.java
@@ -1,0 +1,21 @@
+package io.openur.domain.user.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenHashService {
+
+    public String sha256(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+    }
+}

--- a/src/main/java/io/openur/domain/user/service/login/LoginService.java
+++ b/src/main/java/io/openur/domain/user/service/login/LoginService.java
@@ -19,7 +19,7 @@ public abstract class LoginService {
 
     private final RestTemplate restTemplate;
 
-    public abstract GetUsersLoginDto login(String code, String state) throws JsonProcessingException;
+    public abstract GetUsersLoginDto login(String code, String state, String nonce) throws JsonProcessingException;
 
     protected String getAccessToken(String code, String clientId, String redirectUri, String tokenUri)
         throws JsonProcessingException {

--- a/src/main/java/io/openur/domain/user/service/login/SmartWalletService.java
+++ b/src/main/java/io/openur/domain/user/service/login/SmartWalletService.java
@@ -5,6 +5,7 @@ import io.openur.domain.user.dto.GetUsersLoginDto;
 import io.openur.domain.user.dto.SmartWalletUserInfoDto;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepositoryImpl;
+import io.openur.domain.user.service.LoginNonceService;
 import io.openur.global.common.validation.ValidEthereumAddress;
 import io.openur.global.jwt.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -17,21 +18,29 @@ import org.springframework.web.client.RestTemplate;
 public class SmartWalletService extends LoginService {
     private final JwtUtil jwtUtil;
     private final UserRepositoryImpl userRepository;
+    private final LoginNonceService loginNonceService;
 
     public SmartWalletService(
         RestTemplate restTemplate,
         JwtUtil jwtUtil,
-        UserRepositoryImpl userRepository
+        UserRepositoryImpl userRepository,
+        LoginNonceService loginNonceService
     ) {
         super(restTemplate);
         this.jwtUtil = jwtUtil;
         this.userRepository = userRepository;
+        this.loginNonceService = loginNonceService;
     }
 
     @Override
-    public GetUsersLoginDto login(@ValidEthereumAddress String walletAddress, String signature) throws JsonProcessingException {
+    public GetUsersLoginDto login(
+        @ValidEthereumAddress String walletAddress,
+        String signature,
+        String nonce
+    ) throws JsonProcessingException {
         try {
             log.info("Starting Smart Wallet login process for address: {}", walletAddress);
+            loginNonceService.consume(walletAddress, nonce, signature);
 
             User user = registerUserIfNew(SmartWalletUserInfoDto.of(walletAddress));
             log.info("User found/created successfully. User ID: {}", user.getUserId());

--- a/src/main/java/io/openur/global/config/CorsAllowedOriginPatterns.java
+++ b/src/main/java/io/openur/global/config/CorsAllowedOriginPatterns.java
@@ -1,0 +1,63 @@
+package io.openur.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsConfiguration;
+
+@Component
+public class CorsAllowedOriginPatterns {
+
+    private static final List<String> PROD_VALUES = List.of(
+        "https://open-run.vercel.app",
+        "https://open-run-admin.vercel.app",
+        "https://open-run.xyz",
+        "https://www.open-run.xyz"
+    );
+
+    private static final List<String> LOCAL_VALUES = List.of(
+        "http://localhost:*",
+        "http://127.0.0.1:*",
+        "https://laughably-unblended-tiera.ngrok-free.dev"
+    );
+
+    private final Environment environment;
+    private final CorsConfiguration corsConfiguration = new CorsConfiguration();
+    private List<String> values = PROD_VALUES;
+
+    public CorsAllowedOriginPatterns(Environment environment) {
+        this.environment = environment;
+    }
+
+    @PostConstruct
+    void init() {
+        List<String> resolvedValues = new ArrayList<>(PROD_VALUES);
+        if (environment.acceptsProfiles(Profiles.of("local", "test"))) {
+            resolvedValues.addAll(LOCAL_VALUES);
+        }
+
+        String extraOrigins = environment.getProperty("openrun.cors.extra-allowed-origin-patterns");
+        if (StringUtils.hasText(extraOrigins)) {
+            Arrays.stream(extraOrigins.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .forEach(resolvedValues::add);
+        }
+
+        values = List.copyOf(resolvedValues);
+        corsConfiguration.setAllowedOriginPatterns(values);
+    }
+
+    public List<String> values() {
+        return values;
+    }
+
+    public boolean isAllowed(String origin) {
+        return corsConfiguration.checkOrigin(origin) != null;
+    }
+}

--- a/src/main/java/io/openur/global/config/SecurityConfig.java
+++ b/src/main/java/io/openur/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.openur.global.config;
 
+import io.openur.global.filter.CookieAuthOriginFilter;
 import io.openur.global.filter.JwtAuthenticationFilter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,11 +26,13 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CookieAuthOriginFilter cookieAuthOriginFilter;
+    private final CorsAllowedOriginPatterns corsAllowedOriginPatterns;
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOriginPatterns(corsAllowedOriginPatterns.values());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
@@ -53,6 +56,9 @@ public class SecurityConfig {
             sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         );
 
+        http.addFilterBefore(cookieAuthOriginFilter,
+            UsernamePasswordAuthenticationFilter.class);
+
         http.addFilterBefore(jwtAuthenticationFilter,
             UsernamePasswordAuthenticationFilter.class); // UsernamePasswordAuthenticationFilter 이전에 필터 추가
 
@@ -61,6 +67,9 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/v1/users/login/**",
                     "/v1/users/nickname/exist",
+                    "/v1/auth/login-nonce",
+                    "/v1/auth/refresh",
+                    "/v1/auth/logout",
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
                     "/health",

--- a/src/main/java/io/openur/global/config/WebConfig.java
+++ b/src/main/java/io/openur/global/config/WebConfig.java
@@ -10,12 +10,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
+    private final CorsAllowedOriginPatterns corsAllowedOriginPatterns;
+
+    public WebConfig(CorsAllowedOriginPatterns corsAllowedOriginPatterns) {
+        this.corsAllowedOriginPatterns = corsAllowedOriginPatterns;
+    }
+
     // Swagger uses http "OPTIONS" method before sending actual request
     // We call this as pre-flight : Swagger CORS issue
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOriginPatterns("*")
+            .allowedOriginPatterns(corsAllowedOriginPatterns.values().toArray(String[]::new))
             .allowedMethods("GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE")
             .allowedHeaders("*")
             .allowCredentials(true)

--- a/src/main/java/io/openur/global/filter/CookieAuthOriginFilter.java
+++ b/src/main/java/io/openur/global/filter/CookieAuthOriginFilter.java
@@ -1,0 +1,46 @@
+package io.openur.global.filter;
+
+import io.openur.global.config.CorsAllowedOriginPatterns;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class CookieAuthOriginFilter extends OncePerRequestFilter {
+
+    private final CorsAllowedOriginPatterns corsAllowedOriginPatterns;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return !HttpMethod.POST.matches(request.getMethod())
+            || (!"/v1/auth/login-nonce".equals(requestURI)
+                && !"/v1/auth/refresh".equals(requestURI)
+                && !"/v1/auth/logout".equals(requestURI)
+                && !requestURI.startsWith("/v1/users/login/"));
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String origin = request.getHeader(HttpHeaders.ORIGIN);
+        if (!StringUtils.hasText(origin) || !corsAllowedOriginPatterns.isAllowed(origin)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden origin");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/io/openur/global/jwt/JwtUtil.java
+++ b/src/main/java/io/openur/global/jwt/JwtUtil.java
@@ -26,8 +26,7 @@ public class JwtUtil {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
-    // 토큰 만료시간 TODO : 개발 프로세스 상 너무 짧아 임시 6시간으로 연장합니다, 추후 더 늘릴지, 정책 논의 필요합니다!
-    private final long TOKEN_TIME = 6 * 60 * 60 * 1000L; // 60분
+    private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
     @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
     private String secretKey;

--- a/src/main/resources/application-local.example.properties
+++ b/src/main/resources/application-local.example.properties
@@ -10,3 +10,6 @@ openrun.gcs.public-base-url=https://storage.googleapis.com/openrun-nft
 
 # NFT catalog images are served from a Swarm public gateway (read-only).
 nft.swarm-gateway-url=https://api.gateway.ethswarm.org
+
+# Comma-separated local-only browser origins allowed to send credentialed auth requests.
+openrun.cors.extra-allowed-origin-patterns=http://localhost:*,http://127.0.0.1:*,https://laughably-unblended-tiera.ngrok-free.dev

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,6 +15,33 @@ CREATE TABLE IF NOT EXISTS tb_users
     feedback               INT(4) UNSIGNED                  DEFAULT 0 NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS tb_login_nonces
+(
+    login_nonce_id     VARCHAR(36) DEFAULT (UUID()) PRIMARY KEY NOT NULL,
+    nonce              VARCHAR(96)                              NOT NULL,
+    blockchain_address VARCHAR(42)                              NOT NULL,
+    message            VARCHAR(512)                             NOT NULL,
+    expires_at         TIMESTAMP                                NOT NULL,
+    used               BOOLEAN                                  NOT NULL DEFAULT FALSE,
+    created_at         TIMESTAMP                                NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    used_at            TIMESTAMP                                DEFAULT NULL,
+    CONSTRAINT uq_login_nonce_nonce UNIQUE (nonce),
+    INDEX idx_login_nonce_blockchain_address (blockchain_address)
+);
+
+CREATE TABLE IF NOT EXISTS tb_refresh_tokens
+(
+    refresh_token_id   VARCHAR(36) DEFAULT (UUID()) PRIMARY KEY NOT NULL,
+    token_hash         VARCHAR(64)                              NOT NULL,
+    blockchain_address VARCHAR(42)                              NOT NULL,
+    expires_at         TIMESTAMP                                NOT NULL,
+    revoked            BOOLEAN                                  NOT NULL DEFAULT FALSE,
+    created_at         TIMESTAMP                                NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at         TIMESTAMP                                DEFAULT NULL,
+    CONSTRAINT uq_refresh_token_hash UNIQUE (token_hash),
+    INDEX idx_refresh_token_blockchain_address (blockchain_address)
+);
+
 -- tb_bungs 테이블 생성 (존재하지 않을 경우에만)
 CREATE TABLE IF NOT EXISTS tb_bungs
 (

--- a/src/test/java/io/openur/controller/UserApiTest.java
+++ b/src/test/java/io/openur/controller/UserApiTest.java
@@ -1,5 +1,6 @@
 package io.openur.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,22 +11,34 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openur.config.TestSupport;
 import io.openur.domain.user.dto.GetUserResponseDto;
+import io.openur.domain.user.dto.LoginNonceResponseDto;
 import io.openur.global.dto.Response;
+import jakarta.servlet.http.Cookie;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.Sign;
+import org.web3j.utils.Numeric;
 
 public class UserApiTest extends TestSupport {
 
     private static final String PREFIX = "/v1/users";
+    private static final String REFRESH_TOKEN_COOKIE = "OPENRUN_REFRESH_TOKEN";
+    private static final String ALLOWED_ORIGIN = "https://open-run.vercel.app";
 
     @Test
     @DisplayName("닉네임 중복확인")
@@ -51,6 +64,193 @@ public class UserApiTest extends TestSupport {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.profileImageUrl").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Nested
+    @DisplayName("세션 갱신")
+    class RefreshSessionTest {
+
+        @Test
+        @DisplayName("로그인 성공 시 HttpOnly refresh token cookie를 내려준다")
+        void loginSetsRefreshTokenCookie() throws Exception {
+            MvcResult result = smartWalletLogin(BigInteger.valueOf(1));
+
+            String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+            assertThat(setCookie)
+                .contains(REFRESH_TOKEN_COOKIE + "=")
+                .contains("HttpOnly")
+                .contains("Path=/v1/auth")
+                .contains("SameSite=None");
+        }
+
+        @Test
+        @DisplayName("refresh token으로 access token을 재발급하고 refresh token을 회전한다")
+        void refreshRotatesRefreshToken() throws Exception {
+            MvcResult loginResult = smartWalletLogin(BigInteger.valueOf(2));
+            String oldRefreshToken = extractRefreshToken(loginResult);
+
+            MvcResult refreshResult = mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, oldRefreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.jwtToken").exists())
+                .andReturn();
+
+            String newRefreshToken = extractRefreshToken(refreshResult);
+            assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+
+            mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, oldRefreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("logout은 refresh token을 폐기하고 cookie를 제거한다")
+        void logoutRevokesRefreshToken() throws Exception {
+            MvcResult loginResult = smartWalletLogin(BigInteger.valueOf(3));
+            String refreshToken = extractRefreshToken(loginResult);
+
+            MvcResult logoutResult = mockMvc.perform(
+                    post("/v1/auth/logout")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, refreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+            assertThat(logoutResult.getResponse().getHeader(HttpHeaders.SET_COOKIE))
+                .contains(REFRESH_TOKEN_COOKIE + "=")
+                .contains("Max-Age=0")
+                .contains("Path=/v1/auth");
+
+            mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, refreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("logout은 같은 지갑의 회전된 refresh token도 폐기한다")
+        void logoutRevokesRotatedRefreshTokenForSameWallet() throws Exception {
+            MvcResult loginResult = smartWalletLogin(BigInteger.valueOf(4));
+            String oldRefreshToken = extractRefreshToken(loginResult);
+
+            MvcResult refreshResult = mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, oldRefreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+            String newRefreshToken = extractRefreshToken(refreshResult);
+
+            mockMvc.perform(
+                    post("/v1/auth/logout")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, oldRefreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk());
+
+            mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, newRefreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("cookie 기반 auth endpoint는 Origin이 없으면 거부한다")
+        void cookieAuthEndpointRejectsMissingOrigin() throws Exception {
+            mockMvc.perform(
+                    post("/v1/auth/refresh")
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, "dummy"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isForbidden());
+        }
+
+        private MvcResult smartWalletLogin(BigInteger privateKey) throws Exception {
+            ECKeyPair keyPair = ECKeyPair.create(privateKey);
+            String walletAddress = "0x" + Keys.getAddress(keyPair.getPublicKey());
+            LoginNonceResponseDto loginNonce = issueLoginNonce(walletAddress);
+            String signature = signMessage(loginNonce.getMessage(), keyPair);
+
+            var request = new HashMap<>();
+            request.put("code", walletAddress);
+            request.put("nonce", loginNonce.getNonce());
+            request.put("state", signature);
+
+            return mockMvc.perform(
+                    post(PREFIX + "/login/smart_wallet")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonify(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.jwtToken").exists())
+                .andReturn();
+        }
+
+        private LoginNonceResponseDto issueLoginNonce(String walletAddress) throws Exception {
+            var request = new HashMap<>();
+            request.put("blockchainAddress", walletAddress);
+
+            MvcResult result = mockMvc.perform(
+                    post("/v1/auth/login-nonce")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonify(request))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+            JsonNode data = new ObjectMapper()
+                .readTree(result.getResponse().getContentAsString())
+                .get("data");
+            return new LoginNonceResponseDto(
+                data.get("nonce").asText(),
+                data.get("message").asText()
+            );
+        }
+
+        private String signMessage(String message, ECKeyPair keyPair) {
+            Sign.SignatureData signatureData = Sign.signPrefixedMessage(
+                message.getBytes(StandardCharsets.UTF_8),
+                keyPair
+            );
+            byte[] signature = new byte[65];
+            System.arraycopy(signatureData.getR(), 0, signature, 0, 32);
+            System.arraycopy(signatureData.getS(), 0, signature, 32, 32);
+            System.arraycopy(signatureData.getV(), 0, signature, 64, 1);
+            return Numeric.toHexString(signature);
+        }
+
+        private String extractRefreshToken(MvcResult result) {
+            String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+            assertThat(setCookie).isNotBlank();
+
+            String prefix = REFRESH_TOKEN_COOKIE + "=";
+            assertThat(setCookie).startsWith(prefix);
+
+            int endIndex = setCookie.indexOf(';');
+            assertThat(endIndex).isGreaterThan(prefix.length());
+            return setCookie.substring(prefix.length(), endIndex);
+        }
     }
 
     @Test


### PR DESCRIPTION
## 변경 내용
- refresh token 저장/검증/회전 흐름을 추가했습니다.
- smart wallet 로그인 nonce와 signature 검증 흐름을 분리했습니다.
- refresh token 쿠키 발급, CORS origin pattern, cookie auth origin filter를 추가했습니다.
- 관련 schema와 User API 테스트를 보강했습니다.

## 영향
- 브라우저/앱 로그인 세션을 access token 단독 구조에서 refresh token 기반 세션 구조로 확장합니다.
- 허용 origin과 cookie 기반 인증 흐름이 명시적으로 관리됩니다.

## 검증
- `./gradlew test`
