### PR TITLE
[codex] 완료 벙 피드백 제출 상태 반영

### DIFF
--- a/src/main/java/io/openur/domain/bung/controller/BungController.java
+++ b/src/main/java/io/openur/domain/bung/controller/BungController.java
@@ -111,12 +111,14 @@ public class BungController {
         @RequestParam(required = false, defaultValue = "") Boolean isOwned,
         @Parameter(description = "null : 전부 || PARTICIPATING : 아직 시작하지 않은 || ACCOMPLISHED : 완료된")
         @RequestParam(required = false, defaultValue = "ALL") BungStatus status,
+        @Parameter(description = "true : 피드백 미제출 벙만")
+        @RequestParam(required = false, defaultValue = "false") Boolean feedbackPending,
         @RequestParam(required = false, defaultValue = "0") int page,
         @RequestParam(required = false, defaultValue = "10") int limit
     ) {
         Pageable pageable = PageRequest.of(page, limit);
         Page<BungInfoWithOwnershipDto> contents = bungService.getMyBungLists(
-            userDetails, isOwned, status, pageable);
+            userDetails, isOwned, status, feedbackPending, pageable);
 
         return ResponseEntity.ok().body(
             PagedResponse.build(contents, "success"));

--- a/src/main/java/io/openur/domain/bung/enums/CompleteBungResultEnum.java
+++ b/src/main/java/io/openur/domain/bung/enums/CompleteBungResultEnum.java
@@ -4,6 +4,7 @@ public enum CompleteBungResultEnum {
     SUCCESSFULLY_COMPLETED("successfully completed"),
     BUNG_HAS_ALREADY_COMPLETED("You cannot complete bung - bung has already completed"),
     BUNG_HAS_NOT_STARTED("You cannot complete bung - bung has not started yet"),
+    BUNG_HAS_NOT_COMPLETED("You cannot submit feedback - bung has not completed"),
     ;
 
     private final String value;

--- a/src/main/java/io/openur/domain/bung/repository/BungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/bung/repository/BungRepositoryImpl.java
@@ -20,7 +20,7 @@ import io.openur.domain.bunghashtag.model.BungHashtag;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.service.UserProfileImageUrlResolver;
 import io.openur.domain.userbung.entity.UserBungEntity;
-
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
@@ -49,6 +49,7 @@ public class BungRepositoryImpl implements BungRepository {
     private final JPAQueryFactory queryFactory;
     private final BungJpaRepository bungJpaRepository;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
+    private final EntityManager entityManager;
 
     @Override
     public Page<BungInfoWithMemberListDto> findBungs(
@@ -264,6 +265,9 @@ public class BungRepositoryImpl implements BungRepository {
             .set(bungEntity.completed, true)
             .where(bungEntity.bungId.eq(bungId))
             .execute();
+
+        entityManager.flush();
+        entityManager.clear();
     }
 
     @Override

--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -99,12 +99,12 @@ public class BungService {
     }
     
     public Page<BungInfoWithOwnershipDto> getMyBungLists(
-        UserDetailsImpl userDetails, Boolean isOwned, BungStatus status, Pageable pageable
+        UserDetailsImpl userDetails, Boolean isOwned, BungStatus status, Boolean feedbackPending, Pageable pageable
     ) {
         User user = userRepository.findUser(userDetails.getUser());
 
         return userBungRepository
-            .findJoinedBungsByUserWithStatus(user, isOwned, status, pageable)
+            .findJoinedBungsByUserWithStatus(user, isOwned, status, feedbackPending, pageable)
             .map(BungInfoWithOwnershipDto::new);
     }
 

--- a/src/main/java/io/openur/domain/user/dto/GetFeedbackDto.java
+++ b/src/main/java/io/openur/domain/user/dto/GetFeedbackDto.java
@@ -1,14 +1,14 @@
 package io.openur.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class GetFeedbackDto {
 
-    @NotEmpty
+    @NotNull
     private List<String> targetUserIds;
     @NotBlank
     private String bungId;

--- a/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/user/repository/UserRepositoryImpl.java
@@ -94,14 +94,17 @@ public class UserRepositoryImpl implements UserRepository {
             return List.of();
         }
 
-        // 1. 존재 확인 (1 SELECT) — N+1 find 제거
         Set<String> existingIds = new HashSet<>();
         userJpaRepository.findAllById(targetUserIds)
             .forEach(entity -> existingIds.add(entity.getUserId()));
 
-        // 2. 존재하는 사용자 feedback 단일 bulk update (1 UPDATE)
-        // 기존 dirty checking + merge 패턴은 영속 entity 에 대한 중복 호출이라 제거.
-        // QueryDSL bulk update 는 즉시 DB 반영되며, 호출자 트랜잭션 컨텍스트를 건드리지 않음.
+        List<String> notFoundUserIds = targetUserIds.stream()
+            .filter(id -> !existingIds.contains(id))
+            .toList();
+        if (!notFoundUserIds.isEmpty()) {
+            return notFoundUserIds;
+        }
+
         if (!existingIds.isEmpty()) {
             queryFactory
                 .update(userEntity)
@@ -109,14 +112,10 @@ public class UserRepositoryImpl implements UserRepository {
                 .where(userEntity.userId.in(existingIds))
                 .execute();
 
-            // bulk update 는 1차 캐시를 우회하므로 flush → clear 로 stale entity 정리.
             entityManager.flush();
             entityManager.clear();
         }
 
-        // 3. 미존재 userId 리스트 (입력 순서 보존)
-        return targetUserIds.stream()
-            .filter(id -> !existingIds.contains(id))
-            .toList();
+        return List.of();
     }
 }

--- a/src/main/java/io/openur/domain/user/service/UserService.java
+++ b/src/main/java/io/openur/domain/user/service/UserService.java
@@ -3,15 +3,20 @@ package io.openur.domain.user.service;
 import io.openur.domain.NFT.entity.NftMintJobEntity;
 import io.openur.domain.NFT.enums.NftMintJobStatus;
 import io.openur.domain.NFT.repository.NftMintJobJpaRepository;
+import io.openur.domain.bung.enums.CompleteBungResultEnum;
+import io.openur.domain.bung.exception.CompleteBungException;
 import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.domain.user.dto.GetUsersResponseDto;
 import io.openur.domain.user.dto.PatchUserSurveyRequestDto;
 import io.openur.domain.user.dto.ProfileSummaryResponseDto;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepository;
+import io.openur.domain.userbung.model.UserBung;
 import io.openur.domain.userbung.repository.UserBungRepository;
 import io.openur.global.security.UserDetailsImpl;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -107,10 +112,45 @@ public class UserService {
     @PreAuthorize("@methodSecurityService.isBungParticipant(#userDetails, #bungId)")
     public List<String> increaseFeedback(UserDetailsImpl userDetails, String bungId, List<String> targetUserIds
     ) {
-        if (targetUserIds == null || targetUserIds.isEmpty()) {
-            throw new IllegalArgumentException("Target user IDs cannot be null or empty");
+        if (targetUserIds == null) {
+            throw new IllegalArgumentException("Target user IDs cannot be null");
         }
 
-        return userRepository.batchIncrementFeedback(targetUserIds);
+        UserBung reviewerBung = userBungRepository.findByUserIdAndBungId(
+            userDetails.getUser().getUserId(),
+            bungId
+        );
+        if (reviewerBung.getFeedbackSubmittedAt() != null) {
+            return List.of();
+        }
+        if (!reviewerBung.getBung().isCompleted()) {
+            throw new CompleteBungException(CompleteBungResultEnum.BUNG_HAS_NOT_COMPLETED);
+        }
+
+        String reviewerUserId = userDetails.getUser().getUserId();
+        Set<String> memberUserIds = new LinkedHashSet<>(
+            userBungRepository.findMemberUserIdsByBungId(bungId)
+        );
+        List<String> invalidTargetUserIds = targetUserIds.stream()
+            .filter(targetUserId ->
+                !memberUserIds.contains(targetUserId) || reviewerUserId.equals(targetUserId)
+            )
+            .distinct()
+            .toList();
+        if (!invalidTargetUserIds.isEmpty()) {
+            return invalidTargetUserIds;
+        }
+
+        boolean submitted = userBungRepository.markFeedbackSubmittedIfPending(
+            reviewerUserId,
+            bungId
+        );
+        if (!submitted) {
+            return List.of();
+        }
+
+        return targetUserIds.isEmpty()
+            ? List.of()
+            : userRepository.batchIncrementFeedback(targetUserIds);
     }
 }

--- a/src/main/java/io/openur/domain/userbung/entity/UserBungEntity.java
+++ b/src/main/java/io/openur/domain/userbung/entity/UserBungEntity.java
@@ -41,6 +41,9 @@ public class UserBungEntity {
     @Column(name = "participation_status")
     private boolean participationStatus;
 
+    @Column(name = "feedback_submitted_at")
+    private LocalDateTime feedbackSubmittedAt;
+
     @LastModifiedDate
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime modifiedAt;

--- a/src/main/java/io/openur/domain/userbung/model/UserBung.java
+++ b/src/main/java/io/openur/domain/userbung/model/UserBung.java
@@ -18,6 +18,7 @@ public class UserBung {
     private Bung bung;
     @Setter
     private boolean participationStatus;
+    private LocalDateTime feedbackSubmittedAt;
     private LocalDateTime modifiedAt;
     private boolean isOwner;
 
@@ -25,6 +26,7 @@ public class UserBung {
         this.user = user;
         this.bung = bung;
         this.participationStatus = false;
+        this.feedbackSubmittedAt = null;
         this.modifiedAt = LocalDateTime.now();
         this.isOwner = false;
     }
@@ -41,6 +43,7 @@ public class UserBung {
             User.from(userBungEntity.getUserEntity()),
             Bung.from(userBungEntity.getBungEntity()),
             userBungEntity.isParticipationStatus(),
+            userBungEntity.getFeedbackSubmittedAt(),
             userBungEntity.getModifiedAt(),
             userBungEntity.isOwner()
         );
@@ -60,6 +63,7 @@ public class UserBung {
             this.bung.toEntity(Collections.emptyList()),
             this.user.toEntity(),
             this.participationStatus,
+            this.feedbackSubmittedAt,
             this.modifiedAt,
             this.isOwner
         );

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -21,15 +21,19 @@ public interface UserBungRepository {
     Page<Tuple> findAllFrequentUsers(List<String> bungIds, User user, Pageable pageable);
     
     Page<UserBung> findJoinedBungsByUserWithStatus(
-        User user, Boolean isOwned, BungStatus status, Pageable pageable);
+        User user, Boolean isOwned, BungStatus status, Boolean feedbackPending, Pageable pageable);
 
     List<String> findJoinedBungsId(User user);
+
+    List<String> findMemberUserIdsByBungId(String bungId);
 
     Boolean existsByUserIdAndBungId(String userId, String bungId);
 
     UserBung save(UserBung userBung);
 
     UserBung findByUserIdAndBungId(String userId, String bungId);
+
+    boolean markFeedbackSubmittedIfPending(String userId, String bungId);
 
     UserBung findCurrentOwner(String bungId);
 

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -1,6 +1,5 @@
 package io.openur.domain.userbung.repository;
 
-
 import static io.openur.domain.bung.entity.QBungEntity.bungEntity;
 import static io.openur.domain.bung.enums.BungStatus.ACCOMPLISHED;
 import static io.openur.domain.bunghashtag.entity.QBungHashtagEntity.bungHashtagEntity;
@@ -20,6 +19,7 @@ import io.openur.domain.user.model.User;
 import io.openur.domain.user.service.UserProfileImageUrlResolver;
 import io.openur.domain.userbung.entity.UserBungEntity;
 import io.openur.domain.userbung.model.UserBung;
+import jakarta.persistence.EntityManager;
 import java.awt.HeadlessException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,6 +40,7 @@ public class UserBungRepositoryImpl implements UserBungRepository {
     private final UserBungJpaRepository userBungJpaRepository;
     private final JPAQueryFactory queryFactory;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
+    private final EntityManager entityManager;
 
     @Override
     public int countParticipantsByBungId(String bungId) {
@@ -87,7 +88,7 @@ public class UserBungRepositoryImpl implements UserBungRepository {
 
     @Override
     public Page<UserBung> findJoinedBungsByUserWithStatus(
-        User user, Boolean isOwned, BungStatus status, Pageable pageable) {
+        User user, Boolean isOwned, BungStatus status, Boolean feedbackPending, Pageable pageable) {
         // 1단계: 컬렉션 fetch join 없이 페이징 대상 userBungId만 SQL 레벨에서 조회한다.
         // (hashtag 컬렉션을 fetch join 한 채로 offset/limit 을 적용하면 Hibernate 가
         //  전체 결과를 메모리에 적재한 뒤 페이징하므로 HHH90003004 경고가 발생한다.)
@@ -98,7 +99,8 @@ public class UserBungRepositoryImpl implements UserBungRepository {
             .where(
                 userBungEntity.userEntity.eq(user.toEntity()),
                 ownedBungsOnly(isOwned),
-                withStatusCondition(status)
+                withStatusCondition(status),
+                feedbackPendingOnly(feedbackPending)
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -126,7 +128,8 @@ public class UserBungRepositoryImpl implements UserBungRepository {
             .where(
                 userBungEntity.userEntity.eq(user.toEntity()),
                 ownedBungsOnly(isOwned),
-                withStatusCondition(status)
+                withStatusCondition(status),
+                feedbackPendingOnly(feedbackPending)
             );
 
         return PageableExecutionUtils.getPage(contents, pageable, count::fetchOne);
@@ -139,6 +142,15 @@ public class UserBungRepositoryImpl implements UserBungRepository {
             .from(userBungEntity)
             .join(userBungEntity.bungEntity, bungEntity)
             .where(userBungEntity.userEntity.eq(user.toEntity()))
+            .fetch();
+    }
+
+    @Override
+    public List<String> findMemberUserIdsByBungId(String bungId) {
+        return queryFactory
+            .select(userBungEntity.userEntity.userId)
+            .from(userBungEntity)
+            .where(userBungEntity.bungEntity.bungId.eq(bungId))
             .fetch();
     }
 
@@ -189,6 +201,25 @@ public class UserBungRepositoryImpl implements UserBungRepository {
     }
 
     @Override
+    @Transactional
+    public boolean markFeedbackSubmittedIfPending(String userId, String bungId) {
+        long updatedCount = queryFactory
+            .update(userBungEntity)
+            .set(userBungEntity.feedbackSubmittedAt, LocalDateTime.now())
+            .where(
+                userBungEntity.userEntity.userId.eq(userId),
+                userBungEntity.bungEntity.bungId.eq(bungId),
+                userBungEntity.feedbackSubmittedAt.isNull()
+            )
+            .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return updatedCount > 0;
+    }
+
+    @Override
     public Boolean existsByUserIdAndBungId(String userId, String bungId) {
         return userBungJpaRepository.existsByUserEntity_UserIdAndBungEntity_BungId(userId, bungId);
     }
@@ -234,6 +265,13 @@ public class UserBungRepositoryImpl implements UserBungRepository {
             return null;
         }
         return userBungEntity.isOwner.eq(isOwned);
+    }
+
+    private BooleanExpression feedbackPendingOnly(Boolean feedbackPending) {
+        if (!Boolean.TRUE.equals(feedbackPending)) {
+            return null;
+        }
+        return userBungEntity.feedbackSubmittedAt.isNull();
     }
 
     private BooleanExpression withStatusCondition(BungStatus status) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS tb_users_bungs
     bung_id              VARCHAR(36) DEFAULT (UUID())          NOT NULL,
     user_id              VARCHAR(36) DEFAULT (UUID())          NOT NULL,
     participation_status BOOLEAN     DEFAULT FALSE             NOT NULL,
+    feedback_submitted_at DATETIME   DEFAULT NULL,
     modified_at          TIMESTAMP   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     is_owner             BOOLEAN     DEFAULT FALSE             NOT NULL,
     CONSTRAINT tb_users_bungs_tb_bungs_bung_id_fk

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -326,6 +326,107 @@ public class BungApiTest extends TestSupport {
             assert startDateTimes.equals(
                 sortedStartDateTimes) : "The list is not in descending order of startDateTime";
         }
+
+        @Test
+        @DisplayName("200 OK. isOwned = false, status = ACCOMPLISHED. 일반 참여자가 완료된 벙 피드백 창구로 볼 수 있다.")
+        @Transactional
+        void getMyBungList_completedParticipantBungsForFeedback() throws Exception {
+            String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+
+            mockMvc.perform(
+                patch(PREFIX + "/" + completedBungId + "/complete")
+                    .header(AUTH_HEADER, getTestUserToken2())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            MvcResult result = mockMvc.perform(
+                get(PREFIX + "/my-bungs")
+                    .header(AUTH_HEADER, getTestUserToken1())
+                    .param("isOwned", "false")
+                    .param("status", "ACCOMPLISHED")
+                    .param("feedbackPending", "true")
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+
+            PagedResponse<BungInfoWithOwnershipDto> response = parseResponse(
+                result.getResponse().getContentAsString(),
+                new TypeReference<>() {
+                }
+            );
+
+            assertThat(response.getData())
+                .extracting(BungInfoDto::getBungId)
+                .containsExactly(completedBungId);
+            assertThat(response.getData())
+                .allMatch(bung -> !bung.isHasOwnership());
+        }
+
+        @Test
+        @DisplayName("200 OK. feedbackPending = true. 피드백 제출을 완료한 벙은 목록에서 제외된다.")
+        @Transactional
+        void getMyBungList_feedbackPendingExcludesSubmittedBungs() throws Exception {
+            String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+
+            mockMvc.perform(
+                patch(PREFIX + "/" + completedBungId + "/complete")
+                    .header(AUTH_HEADER, getTestUserToken2())
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            var feedbackRequest = new HashMap<>();
+            feedbackRequest.put("bungId", completedBungId);
+            feedbackRequest.put("targetUserIds", List.of());
+
+            mockMvc.perform(
+                patch("/v1/users/feedback")
+                    .header(AUTH_HEADER, getTestUserToken1())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonify(feedbackRequest))
+            ).andExpect(status().isOk());
+
+            MvcResult pendingResult = mockMvc.perform(
+                get(PREFIX + "/my-bungs")
+                    .header(AUTH_HEADER, getTestUserToken1())
+                    .param("isOwned", "false")
+                    .param("status", "ACCOMPLISHED")
+                    .param("feedbackPending", "true")
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+
+            PagedResponse<BungInfoWithOwnershipDto> pendingResponse = parseResponse(
+                pendingResult.getResponse().getContentAsString(),
+                new TypeReference<>() {
+                }
+            );
+
+            assertThat(pendingResponse.getData())
+                .extracting(BungInfoDto::getBungId)
+                .doesNotContain(completedBungId);
+
+            MvcResult allCompletedResult = mockMvc.perform(
+                get(PREFIX + "/my-bungs")
+                    .header(AUTH_HEADER, getTestUserToken1())
+                    .param("isOwned", "false")
+                    .param("status", "ACCOMPLISHED")
+                    .param("page", "0")
+                    .param("limit", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk()).andReturn();
+
+            PagedResponse<BungInfoWithOwnershipDto> allCompletedResponse = parseResponse(
+                allCompletedResult.getResponse().getContentAsString(),
+                new TypeReference<>() {
+                }
+            );
+
+            assertThat(allCompletedResponse.getData())
+                .extracting(BungInfoDto::getBungId)
+                .contains(completedBungId);
+        }
     }
 
     @Nested

--- a/src/test/java/io/openur/controller/UserApiTest.java
+++ b/src/test/java/io/openur/controller/UserApiTest.java
@@ -1,5 +1,6 @@
 package io.openur.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -13,12 +14,15 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.openur.config.TestSupport;
 import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.global.dto.Response;
+import jakarta.persistence.EntityManager;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserApiTest extends TestSupport {
 
     private static final String PREFIX = "/v1/users";
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
     @DisplayName("닉네임 중복확인")
@@ -55,6 +63,7 @@ public class UserApiTest extends TestSupport {
 
     @Test
     @DisplayName("프로필 요약")
+    @Transactional
     void getProfileSummaryTest() throws Exception {
         when(nftMintClient.mintToken(any(String.class), any(BigInteger.class), any(BigInteger.class)))
             .thenReturn("0xtxhash");
@@ -73,8 +82,15 @@ public class UserApiTest extends TestSupport {
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk());
 
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
         var feedbackRequest = new HashMap<>();
-        feedbackRequest.put("bungId", "c0477004-1632-455f-acc9-04584b55921f");
+        feedbackRequest.put("bungId", completedBungId);
         feedbackRequest.put("targetUserIds", List.of("9e1bfc60-f76a-47dc-9147-803653707192"));
 
         mockMvc.perform(
@@ -98,6 +114,276 @@ public class UserApiTest extends TestSupport {
             .andExpect(jsonPath("$.data.recentAcquiredNfts[0].challengeName").exists())
             .andExpect(jsonPath("$.data.recentAcquiredNfts[0].acquiredAt").exists())
             .andExpect(jsonPath("$.data.recentAcquiredNfts[0].nft.transactionHash").value("0xtxhash"));
+    }
+
+    @Test
+    @DisplayName("빈 피드백 저장도 벙 피드백 제출 완료로 기록한다")
+    @Transactional
+    void increaseFeedback_emptyTargetsMarksFeedbackSubmitted() throws Exception {
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        String reviewerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", completedBungId);
+        feedbackRequest.put("targetUserIds", List.of());
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isOk());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Boolean submitted = jdbcTemplate.queryForObject(
+            """
+                SELECT feedback_submitted_at IS NOT NULL
+                FROM tb_users_bungs
+                WHERE bung_id = ? AND user_id = ?
+                """,
+            Boolean.class,
+            completedBungId,
+            reviewerUserId
+        );
+
+        assertThat(submitted).isTrue();
+    }
+
+    @Test
+    @DisplayName("같은 벙 멤버가 아닌 유저에게는 피드백을 남길 수 없다")
+    @Transactional
+    void increaseFeedback_nonMemberTargetDoesNotIncrementOrMarkSubmitted() throws Exception {
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        String reviewerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+        String nonMemberUserId = "5d22bd65-f1ed-4e7b-bc7b-0a59580d3176";
+
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", completedBungId);
+        feedbackRequest.put("targetUserIds", List.of(nonMemberUserId));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isNotFound());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Integer feedback = jdbcTemplate.queryForObject(
+            "SELECT feedback FROM tb_users WHERE user_id = ?",
+            Integer.class,
+            nonMemberUserId
+        );
+        Boolean submitted = jdbcTemplate.queryForObject(
+            """
+                SELECT feedback_submitted_at IS NOT NULL
+                FROM tb_users_bungs
+                WHERE bung_id = ? AND user_id = ?
+                """,
+            Boolean.class,
+            completedBungId,
+            reviewerUserId
+        );
+
+        assertThat(feedback).isZero();
+        assertThat(submitted).isFalse();
+    }
+
+    @Test
+    @DisplayName("자기 자신에게는 피드백을 남길 수 없다")
+    @Transactional
+    void increaseFeedback_selfTargetDoesNotIncrementOrMarkSubmitted() throws Exception {
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        String reviewerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", completedBungId);
+        feedbackRequest.put("targetUserIds", List.of(reviewerUserId));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isNotFound());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Integer feedback = jdbcTemplate.queryForObject(
+            "SELECT feedback FROM tb_users WHERE user_id = ?",
+            Integer.class,
+            reviewerUserId
+        );
+        Boolean submitted = jdbcTemplate.queryForObject(
+            """
+                SELECT feedback_submitted_at IS NOT NULL
+                FROM tb_users_bungs
+                WHERE bung_id = ? AND user_id = ?
+                """,
+            Boolean.class,
+            completedBungId,
+            reviewerUserId
+        );
+
+        assertThat(feedback).isZero();
+        assertThat(submitted).isFalse();
+    }
+
+    @Test
+    @DisplayName("일부 target 이 유효하지 않으면 유효한 유저도 부분 증가시키지 않는다")
+    @Transactional
+    void increaseFeedback_mixedInvalidTargetDoesNotPartiallyIncrement() throws Exception {
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        String reviewerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+        String validTargetUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+        String invalidUserId = "00000000-0000-0000-0000-000000000000";
+
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", completedBungId);
+        feedbackRequest.put("targetUserIds", List.of(validTargetUserId, invalidUserId));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isNotFound());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Integer feedback = jdbcTemplate.queryForObject(
+            "SELECT feedback FROM tb_users WHERE user_id = ?",
+            Integer.class,
+            validTargetUserId
+        );
+        Boolean submitted = jdbcTemplate.queryForObject(
+            """
+                SELECT feedback_submitted_at IS NOT NULL
+                FROM tb_users_bungs
+                WHERE bung_id = ? AND user_id = ?
+                """,
+            Boolean.class,
+            completedBungId,
+            reviewerUserId
+        );
+
+        assertThat(feedback).isZero();
+        assertThat(submitted).isFalse();
+    }
+
+    @Test
+    @DisplayName("완료되지 않은 벙에는 피드백을 저장할 수 없다")
+    @Transactional
+    void increaseFeedback_uncompletedBungDoesNotSubmit() throws Exception {
+        String notCompletedBungId = "c0477004-1632-455f-acc9-04584b55921f";
+        String reviewerUserId = "9e1bfc60-f76a-47dc-9147-803653707192";
+        String targetUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", notCompletedBungId);
+        feedbackRequest.put("targetUserIds", List.of(targetUserId));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isConflict());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Integer feedback = jdbcTemplate.queryForObject(
+            "SELECT feedback FROM tb_users WHERE user_id = ?",
+            Integer.class,
+            targetUserId
+        );
+        Boolean submitted = jdbcTemplate.queryForObject(
+            """
+                SELECT feedback_submitted_at IS NOT NULL
+                FROM tb_users_bungs
+                WHERE bung_id = ? AND user_id = ?
+                """,
+            Boolean.class,
+            notCompletedBungId,
+            reviewerUserId
+        );
+
+        assertThat(feedback).isZero();
+        assertThat(submitted).isFalse();
+    }
+
+    @Test
+    @DisplayName("같은 벙 피드백을 다시 저장해도 피드백 수는 한 번만 증가한다")
+    @Transactional
+    void increaseFeedback_duplicateSubmissionDoesNotIncrementAgain() throws Exception {
+        String completedBungId = "a1234567-89ab-cdef-0123-456789abcdef";
+        String targetUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+        mockMvc.perform(
+            patch("/v1/bungs/" + completedBungId + "/complete")
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", completedBungId);
+        feedbackRequest.put("targetUserIds", List.of(targetUserId));
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isOk());
+
+        mockMvc.perform(
+            patch(PREFIX + "/feedback")
+                .header(AUTH_HEADER, getTestUserToken1())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isOk());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Integer feedback = jdbcTemplate.queryForObject(
+            "SELECT feedback FROM tb_users WHERE user_id = ?",
+            Integer.class,
+            targetUserId
+        );
+
+        assertThat(feedback).isOne();
     }
 
     @Nested


### PR DESCRIPTION
## 변경 사항

- 완료된 벙에서 일반 참여자가 피드백을 저장하면 `tb_users_bungs.feedback_submitted_at`을 기록합니다.
- 프로필 피드백 리스트는 완료됐고 아직 피드백 제출이 끝나지 않은 참여 벙만 조회하도록 지원합니다.
- 피드백 target은 같은 벙 멤버이면서 자기 자신이 아닌 경우만 허용합니다.
- 빈 피드백 저장, 비멤버/자기 자신 target, mixed invalid target, 중복 제출, pending 조회 테스트를 추가했습니다.

## 검증

- `./gradlew test --rerun-tasks --tests 'io.openur.controller.UserApiTest' --tests 'io.openur.controller.BungApiTest$getMyBungListTest'`
- `git diff --check`
