### PR TITLE
feat: 어드민 도전과제 완료 유저 조회 및 NFT 보유 조회

### DIFF
--- a/src/main/java/io/openur/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/openur/domain/admin/controller/AdminController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -84,6 +85,19 @@ public class AdminController {
         return ResponseEntity.ok(Response.<List<NftAvatarItemDto>>builder()
             .data(adminNftService.getTryOnAvatarItems())
             .message("Admin NFT avatar try-on items fetched successfully")
+            .build());
+    }
+
+    @GetMapping("/nft/avatar-items/owned")
+    public ResponseEntity<Response<List<NftAvatarItemDto>>> getOwnedNftAvatarItems(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam("address") String address
+    ) {
+        adminAuthorizationService.assertAdmin(userDetails);
+
+        return ResponseEntity.ok(Response.<List<NftAvatarItemDto>>builder()
+            .data(adminNftService.getOwnedAvatarItems(address))
+            .message("Admin owned NFT avatar items fetched successfully")
             .build());
     }
 

--- a/src/main/java/io/openur/domain/admin/controller/AdminController.java
+++ b/src/main/java/io/openur/domain/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package io.openur.domain.admin.controller;
 
 import io.openur.domain.NFT.dto.NftAvatarItemDto;
+import io.openur.domain.admin.dto.AdminChallengeCompletionDto;
 import io.openur.domain.admin.dto.AdminChallengeDto;
 import io.openur.domain.admin.dto.AdminChallengeRequestDto;
 import io.openur.domain.admin.dto.AdminMeDto;
@@ -121,6 +122,19 @@ public class AdminController {
         return ResponseEntity.ok(Response.<AdminChallengeDto>builder()
             .data(adminChallengeService.getChallenge(challengeId))
             .message("Admin challenge fetched successfully")
+            .build());
+    }
+
+    @GetMapping("/challenges/{challengeId}/completions")
+    public ResponseEntity<Response<List<AdminChallengeCompletionDto>>> getAdminChallengeCompletions(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long challengeId
+    ) {
+        adminAuthorizationService.assertAdmin(userDetails);
+
+        return ResponseEntity.ok(Response.<List<AdminChallengeCompletionDto>>builder()
+            .data(adminChallengeService.getChallengeCompletions(challengeId))
+            .message("Admin challenge completions fetched successfully")
             .build());
     }
 

--- a/src/main/java/io/openur/domain/admin/dto/AdminChallengeCompletionDto.java
+++ b/src/main/java/io/openur/domain/admin/dto/AdminChallengeCompletionDto.java
@@ -1,0 +1,31 @@
+package io.openur.domain.admin.dto;
+
+import io.openur.domain.userchallenge.entity.UserChallengeEntity;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminChallengeCompletionDto {
+
+    private Long userChallengeId;
+    private String userId;
+    private String nickname;
+    private Integer stageNumber;
+    private Integer conditionCount;
+    private LocalDateTime completedDate;
+    private boolean nftCompleted;
+
+    public static AdminChallengeCompletionDto from(UserChallengeEntity entity) {
+        return AdminChallengeCompletionDto.builder()
+            .userChallengeId(entity.getUserChallengeId())
+            .userId(entity.getUserEntity().getUserId())
+            .nickname(entity.getUserEntity().getNickname())
+            .stageNumber(entity.getChallengeStageEntity().getStageNumber())
+            .conditionCount(entity.getChallengeStageEntity().getConditionAsCount())
+            .completedDate(entity.getCompletedDate())
+            .nftCompleted(Boolean.TRUE.equals(entity.getNftCompleted()))
+            .build();
+    }
+}

--- a/src/main/java/io/openur/domain/admin/service/AdminChallengeService.java
+++ b/src/main/java/io/openur/domain/admin/service/AdminChallengeService.java
@@ -1,5 +1,6 @@
 package io.openur.domain.admin.service;
 
+import io.openur.domain.admin.dto.AdminChallengeCompletionDto;
 import io.openur.domain.admin.dto.AdminChallengeDto;
 import io.openur.domain.admin.dto.AdminChallengeRequestDto;
 import io.openur.domain.admin.dto.AdminChallengeStageRequestDto;
@@ -37,6 +38,16 @@ public class AdminChallengeService {
     @Transactional(readOnly = true)
     public AdminChallengeDto getChallenge(Long challengeId) {
         return toDto(getChallengeEntity(challengeId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminChallengeCompletionDto> getChallengeCompletions(Long challengeId) {
+        getChallengeEntity(challengeId);
+
+        return userChallengeJpaRepository.findCompletionsByChallengeId(challengeId)
+            .stream()
+            .map(AdminChallengeCompletionDto::from)
+            .toList();
     }
 
     @Transactional

--- a/src/main/java/io/openur/domain/admin/service/AdminNftService.java
+++ b/src/main/java/io/openur/domain/admin/service/AdminNftService.java
@@ -6,11 +6,13 @@ import io.openur.domain.NFT.enums.NftImageRole;
 import io.openur.domain.NFT.repository.NftJpaRepository;
 import io.openur.domain.NFT.repository.NftTokenJpaRepository;
 import io.openur.domain.NFT.service.NftAssetUrlResolver;
+import io.openur.domain.NFT.service.NftAvatarItemService;
 import io.openur.domain.NFT.service.NftAvatarItemViewMapper;
 import io.openur.domain.NFT.service.NftMintClient;
 import io.openur.domain.admin.dto.AdminNftGrantRequestDto;
 import io.openur.domain.admin.dto.AdminNftGrantResponseDto;
 import io.openur.domain.admin.dto.AdminNftItemDto;
+import io.openur.global.common.validation.EthereumAddressValidator;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -30,11 +32,15 @@ public class AdminNftService {
     private final NftTokenJpaRepository nftTokenJpaRepository;
     private final NftAssetUrlResolver nftAssetUrlResolver;
     private final NftAvatarItemViewMapper nftAvatarItemViewMapper;
+    private final NftAvatarItemService nftAvatarItemService;
     private final NftMintClient nftMintClient;
+    private final EthereumAddressValidator ethereumAddressValidator;
 
     @Transactional(readOnly = true)
     public List<AdminNftItemDto> getMintedAvatarItems() {
-        return nftTokenJpaRepository.findByImageRoleOrderByNftNftIdAsc(NftImageRole.thumbnail)
+        // 발급(grant)·보유 조회 모두 avatar role 토큰 기준이므로 목록도 avatar 토큰의 tokenId를 내려준다.
+        // thumbnail role 토큰의 tokenId를 내려주면 grant 검증(findByTokenIdAndImageRole(avatar))에서 실패한다.
+        return nftTokenJpaRepository.findByImageRoleOrderByNftNftIdAsc(NftImageRole.avatar)
             .stream()
             .map(token -> AdminNftItemDto.from(
                 token.getNft(), token.getTokenId(), nftAssetUrlResolver, nftAvatarItemViewMapper))
@@ -56,6 +62,19 @@ public class AdminNftService {
                 nft, avatarTokenIdByNftId.get(nft.getNftId()), null))
             .map(this::normalizeEmptyImageUrl)
             .toList();
+    }
+
+    public List<NftAvatarItemDto> getOwnedAvatarItems(String ownerAddress) {
+        if (!ethereumAddressValidator.isValid(ownerAddress)) {
+            throw new IllegalArgumentException("invalid ethereum address");
+        }
+
+        try {
+            return nftAvatarItemService.getOwnedAvatarItems(ownerAddress);
+        } catch (RuntimeException e) {
+            // RPC 실패 등 내부 예외 메시지를 어드민 화면에 그대로 노출하지 않는다
+            throw new IllegalStateException("블록체인 잔액 조회에 실패했습니다. 잠시 후 다시 시도해 주세요.", e);
+        }
     }
 
     public AdminNftGrantResponseDto grantAvatarItem(AdminNftGrantRequestDto request) {

--- a/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeJpaRepository.java
+++ b/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeJpaRepository.java
@@ -1,11 +1,24 @@
 package io.openur.domain.userchallenge.repository;
 
 import io.openur.domain.userchallenge.entity.UserChallengeEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserChallengeJpaRepository extends JpaRepository<UserChallengeEntity, Long> {
+
+    @Query("""
+        select uc from UserChallengeEntity uc
+        join fetch uc.userEntity
+        join fetch uc.challengeStageEntity cs
+        where cs.challengeEntity.challengeId = :challengeId
+          and uc.completedDate is not null
+        order by uc.completedDate desc, uc.userChallengeId desc
+        """)
+    List<UserChallengeEntity> findCompletionsByChallengeId(@Param("challengeId") Long challengeId);
 
     @EntityGraph(attributePaths = {
         "userEntity",

--- a/src/test/java/io/openur/controller/AdminNftApiTest.java
+++ b/src/test/java/io/openur/controller/AdminNftApiTest.java
@@ -248,7 +248,7 @@ public class AdminNftApiTest extends TestSupport {
                 )
             )
             .andExpect(jsonPath("$.data", hasSize(5)))
-            .andExpect(jsonPath("$.data[0].tokenId").value("1001"))
+            .andExpect(jsonPath("$.data[0].tokenId").value("100"))
             .andExpect(jsonPath("$.data[0].name").value("테스트 상의"))
             .andExpect(jsonPath("$.data[0].category").value("top"))
             .andExpect(
@@ -259,12 +259,12 @@ public class AdminNftApiTest extends TestSupport {
             .andExpect(
                 jsonPath("$.data[0].thumbnailUrl").value(GW + "01a0" + F)
             )
-            .andExpect(jsonPath("$.data[3].tokenId").value("1006"))
+            .andExpect(jsonPath("$.data[3].tokenId").value("500"))
             .andExpect(jsonPath("$.data[3].mainCategory").value("accessories"))
             .andExpect(
                 jsonPath("$.data[3].subCategory").value("eye-accessories")
             )
-            .andExpect(jsonPath("$.data[*].tokenId").value(hasItem("1007")))
+            .andExpect(jsonPath("$.data[*].tokenId").value(hasItem("600")))
             .andExpect(
                 jsonPath("$.data[*].name").value(
                     not(hasItem("토큰 없는 아이템"))


### PR DESCRIPTION
## 변경 사항

### 1. 어드민 도전과제 완료 유저 조회
- `GET /v1/admin/challenges/{challengeId}/completions` 엔드포인트 신설
- 완료 기록을 유저·스테이지와 fetch join 단일 쿼리로 조회 (닉네임, 단계, 달성 횟수, 완료 일시, NFT 수령 여부)
- 어드민 도전과제 상세 화면의 "완료한 유저" 섹션에서 사용

### 2. 어드민 NFT 보유 조회 + 발급 목록 수정
- `GET /v1/admin/nft/avatar-items/owned` 추가 (지갑 주소 기준 보유 아이템 조회)
- 민팅 아이템 목록을 thumbnail → avatar 토큰 기준으로 수정: 기존 목록의 tokenId로는 발급(grant) 검증이 항상 400으로 실패하던 버그 해결
- `AdminNftApiTest` 단언을 avatar 토큰 ID로 갱신

## 검증

- `./gradlew compileJava` 통과
- `./gradlew test --tests "io.openur.controller.AdminNftApiTest"` 통과
- 독립 리뷰어 코드리뷰 완료 (N+1 없음 확인, EntityGraph→fetch join 단일 쿼리, 기존 엔드포인트 무영향)

🤖 Generated with [Claude Code](https://claude.com/claude-code)