### PR TITLE
fix: 배포 스크립트 컨테이너 이름 부분 일치 문제 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,11 +142,9 @@ jobs:
         # Pull the latest docker image
         gcloud compute ssh ${{ env.INSTANCE_NAME }} --zone=${{ env.ZONE }} --command="docker pull ${{ env.DOCKER_CONTAINER_PATH }}/${{ env.DOCKER_REPOSITORY_NAME }}/${{ env.DOCKER_IMAGE_NAME }}:latest"
 
-        CONTAINER_ID=$(gcloud compute ssh ${{ env.INSTANCE_NAME }} --zone=${{ env.ZONE }} --command="docker ps -q -f name=openrun" | tr -d '\n')
-        if [ -n "$CONTAINER_ID" ]; then
-          echo "Openrun container already exists, stopping and removing it..."
-          gcloud compute ssh ${{ env.INSTANCE_NAME }} --zone=${{ env.ZONE }} --command="docker stop $CONTAINER_ID && docker rm $CONTAINER_ID"
-        fi
+        # 이전 컨테이너를 정확한 이름으로 제거한다. name 필터는 부분 일치라
+        # 같은 VM의 openrun-web/openrun-admin까지 걸리므로 사용하지 않는다.
+        gcloud compute ssh ${{ env.INSTANCE_NAME }} --zone=${{ env.ZONE }} --command="docker rm -f openrun 2>/dev/null || true"
         
         # Run the application container on the same Docker network as MySQL
         gcloud compute ssh ${{ env.INSTANCE_NAME }} --zone=${{ env.ZONE }} --command="docker run -d \


### PR DESCRIPTION
## 문제

프론트엔드가 같은 VM으로 이관되면서 `openrun-web`, `openrun-admin` 컨테이너가 추가됐는데, 배포 스크립트의 `docker ps -q -f name=openrun`이 **부분 일치**라 세 컨테이너의 ID가 모두 잡혀 한 줄로 이어붙고, 존재하지 않는 ID로 `docker stop`을 시도하다 배포가 실패함 ([실패 run](https://github.com/open-run/backend/actions/runs/29643050657) — "No such container").

## 수정

- ID 조회 + stop/rm 조합을 `docker rm -f openrun`(정확한 이름 지정, 멱등) 단일 명령으로 교체 — frontend deploy.yml과 동일한 방식

## 영향

- 백엔드 배포 정상화. 애플리케이션 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)