### PR TITLE
feat: 도전과제 활동별 트리거 연결

### DIFF
--- a/src/main/java/io/openur/domain/bung/service/BungService.java
+++ b/src/main/java/io/openur/domain/bung/service/BungService.java
@@ -22,12 +22,12 @@ import io.openur.domain.bung.exception.SearchBungException;
 import io.openur.domain.bung.model.Bung;
 import io.openur.domain.bung.repository.BungRepository;
 import io.openur.domain.bunghashtag.repository.BungHashtagRepository;
+import io.openur.domain.challenge.enums.ChallengeActivityType;
 import io.openur.domain.challenge.event.ChallengeEventsPublisher;
 import io.openur.domain.hashtag.model.Hashtag;
 import io.openur.domain.hashtag.repository.HashtagRepository;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepository;
-import io.openur.domain.userbung.dto.UserBungInfoDto;
 import io.openur.domain.userbung.model.UserBung;
 import io.openur.domain.userbung.repository.UserBungRepository;
 import io.openur.global.security.UserDetailsImpl;
@@ -62,7 +62,10 @@ public class BungService {
     ) {
         List<Hashtag> hashtags = hashtagRepository.saveNotListedTags(dto.getHashtags());
         Bung bung = this.saveNewBung(userDetails, dto, hashtags);
-        
+
+        challengeEventsPublisher.publishChallengeCheck(
+            userDetails.getUser().getUserId(), ChallengeActivityType.BUNG_CREATE);
+
         return new BungInfoDto(bung);
     }
     
@@ -166,6 +169,10 @@ public class BungService {
         }
 
         userBungRepository.save(new UserBung(userDetails.getUser(), new Bung(bungWithMembers)));
+
+        challengeEventsPublisher.publishChallengeCheck(
+            userDetails.getUser().getUserId(), ChallengeActivityType.BUNG_JOIN);
+
         return JoinBungResultEnum.SUCCESSFULLY_JOINED;
     }
 
@@ -233,11 +240,9 @@ public class BungService {
 
         bungRepository.setAsCompleted(bungId);
 
-        //TODO: EventPublisher 로 도전과제 부가 기능 연산 필요, 도전과제에 따라 bung 이 가진 필드를 가져가는 DTO 가 필요할것
-        getBungDetail(bungId).getMemberList().stream()
-            .filter(UserBungInfoDto::isParticipationStatus)
-            .map(UserBungInfoDto::getUserId)
-            .forEach(challengeEventsPublisher::publishBulkChallengeCheck);
+        // 완주 과제는 벙주는 완료 시점에, 벙원은 피드백 제출 시점에 카운트한다
+        challengeEventsPublisher.publishChallengeCheck(
+            userDetails.getUser().getUserId(), ChallengeActivityType.BUNG_COMPLETE);
 
         return CompleteBungResultEnum.SUCCESSFULLY_COMPLETED;
     }

--- a/src/main/java/io/openur/domain/challenge/enums/ChallengeActivityType.java
+++ b/src/main/java/io/openur/domain/challenge/enums/ChallengeActivityType.java
@@ -1,0 +1,25 @@
+package io.openur.domain.challenge.enums;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 유저 활동과 그 활동으로 진행되는 도전과제 ID 매핑.
+ * 과제 스펙이 코드 배포 없이 바뀌는 구조가 되면 tb_challenges 컬럼으로 이전을 검토한다.
+ *
+ * 완주(BUNG_COMPLETE)는 벙주는 벙 완료 시점, 벙원은 완료된 벙에 첫 피드백을
+ * 제출한 시점에 카운트한다. 참여 인증 여부는 조건이 아니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeActivityType {
+    BUNG_CREATE(List.of(2L, 6L)),
+    BUNG_JOIN(List.of(3L, 5L)),
+    BUNG_CERTIFY(List.of(4L)),
+    BUNG_COMPLETE(List.of(7L, 19L)),
+    // TODO: 프로필 완성 API에 배선 예정
+    PROFILE_COMPLETE(List.of(8L));
+
+    private final List<Long> challengeIds;
+}

--- a/src/main/java/io/openur/domain/challenge/enums/ChallengeActivityType.java
+++ b/src/main/java/io/openur/domain/challenge/enums/ChallengeActivityType.java
@@ -17,9 +17,7 @@ public enum ChallengeActivityType {
     BUNG_CREATE(List.of(2L, 6L)),
     BUNG_JOIN(List.of(3L, 5L)),
     BUNG_CERTIFY(List.of(4L)),
-    BUNG_COMPLETE(List.of(7L, 19L)),
-    // TODO: 프로필 완성 API에 배선 예정
-    PROFILE_COMPLETE(List.of(8L));
+    BUNG_COMPLETE(List.of(7L, 19L));
 
     private final List<Long> challengeIds;
 }

--- a/src/main/java/io/openur/domain/challenge/event/ChallengeEventsPublisher.java
+++ b/src/main/java/io/openur/domain/challenge/event/ChallengeEventsPublisher.java
@@ -1,5 +1,6 @@
 package io.openur.domain.challenge.event;
 
+import io.openur.domain.challenge.enums.ChallengeActivityType;
 import io.openur.domain.userchallenge.model.UserChallenge;
 import io.openur.domain.userchallenge.repository.UserChallengeRepository;
 import io.openur.domain.userchallenge.service.UserChallengeInitializer;
@@ -18,29 +19,18 @@ public class ChallengeEventsPublisher {
     private final UserChallengeInitializer userChallengeInitializer;
 
     @Transactional
-    public void publishChallengeCheck(String userId) {
+    public void publishChallengeCheck(String userId, ChallengeActivityType activity) {
         userChallengeInitializer.ensureInitialized(userId);
 
-        userChallengeRepository.findFirstBySimpleRepetitiveChallenge(userId)
-            .ifPresent(userChallenge -> {
-                if (userChallenge.getCurrentCount() + 1 < userChallenge.getChallengeStage().getConditionAsCount())
-                    publisher.publishEvent(new OnRaise(List.of(userChallenge)));
-                else
-                    publisher.publishEvent(new OnEvolution(List.of(userChallenge)));
-            });
-    }
+        List<UserChallenge> targets =
+            userChallengeRepository.findAllUncompletedByChallengeIds(
+                userId, activity.getChallengeIds());
+        if (targets.isEmpty()) return;
 
-    @Transactional
-    public void publishBulkChallengeCheck(String userId) {
-        userChallengeInitializer.ensureInitialized(userId);
-
-        List<UserChallenge> all = userChallengeRepository.findAllBySimpleRepetitiveChallenge(userId);
-        if (all.isEmpty()) return;
-
-        List<UserChallenge> toRaise = all.stream()
+        List<UserChallenge> toRaise = targets.stream()
             .filter(uc -> uc.getCurrentCount() + 1 < uc.getChallengeStage().getConditionAsCount())
             .toList();
-        List<UserChallenge> toEvolve = all.stream()
+        List<UserChallenge> toEvolve = targets.stream()
             .filter(uc -> uc.getCurrentCount() + 1 >= uc.getChallengeStage().getConditionAsCount())
             .toList();
 

--- a/src/main/java/io/openur/domain/challenge/model/ChallengeStage.java
+++ b/src/main/java/io/openur/domain/challenge/model/ChallengeStage.java
@@ -23,21 +23,14 @@ public class ChallengeStage {
         );
     }
 
-    public ChallengeStageEntity toEntity(Challenge challenge) {
-        return new ChallengeStageEntity(
-            this.stageId,
-            this.stageNumber,
-            this.conditionAsCount,
-            challenge.toEntity()
-        );
-    }
-
     public ChallengeStageEntity toEntity() {
+        // challenge 참조를 null로 저장하면 같은 트랜잭션에서 1차 캐시로 재조회될 때
+        // ChallengeStage.from()이 NPE로 죽는다. 모델이 들고 있는 값을 그대로 복원한다.
         return new ChallengeStageEntity(
             this.stageId,
             this.stageNumber,
             this.conditionAsCount,
-            null
+            this.challenge != null ? this.challenge.toEntity() : null
         );
     }
 }

--- a/src/main/java/io/openur/domain/user/service/UserService.java
+++ b/src/main/java/io/openur/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import io.openur.domain.NFT.enums.NftMintJobStatus;
 import io.openur.domain.NFT.repository.NftMintJobJpaRepository;
 import io.openur.domain.bung.enums.CompleteBungResultEnum;
 import io.openur.domain.bung.exception.CompleteBungException;
+import io.openur.domain.challenge.enums.ChallengeActivityType;
+import io.openur.domain.challenge.event.ChallengeEventsPublisher;
 import io.openur.domain.user.dto.GetUserResponseDto;
 import io.openur.domain.user.dto.GetUsersResponseDto;
 import io.openur.domain.user.dto.PatchUserSurveyRequestDto;
@@ -34,6 +36,7 @@ public class UserService {
     private final UserBungRepository userBungRepository;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
     private final NftMintJobJpaRepository nftMintJobJpaRepository;
+    private final ChallengeEventsPublisher challengeEventsPublisher;
 
     public String getUserById(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userRepository.findUser(userDetails.getUser());
@@ -147,6 +150,12 @@ public class UserService {
         );
         if (!submitted) {
             return List.of();
+        }
+
+        // 벙원의 완주 과제는 최초 피드백 제출 시점에 카운트한다 (벙주는 완료 시점에 이미 카운트됨)
+        if (!reviewerBung.isOwner()) {
+            challengeEventsPublisher.publishChallengeCheck(
+                reviewerUserId, ChallengeActivityType.BUNG_COMPLETE);
         }
 
         return targetUserIds.isEmpty()

--- a/src/main/java/io/openur/domain/userbung/model/UserBung.java
+++ b/src/main/java/io/openur/domain/userbung/model/UserBung.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @AllArgsConstructor
@@ -16,7 +15,6 @@ public class UserBung {
     private Long userBungId;
     private User user;
     private Bung bung;
-    @Setter
     private boolean participationStatus;
     private LocalDateTime feedbackSubmittedAt;
     private LocalDateTime modifiedAt;

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepository.java
@@ -31,6 +31,12 @@ public interface UserBungRepository {
 
     UserBung save(UserBung userBung);
 
+    /**
+     * 참여 인증을 조건부 UPDATE로 처리한다.
+     * @return 미인증 → 인증으로 실제 전환됐으면 true, 이미 인증 상태였으면 false
+     */
+    boolean confirmParticipation(String userId, String bungId);
+
     UserBung findByUserIdAndBungId(String userId, String bungId);
 
     boolean markFeedbackSubmittedIfPending(String userId, String bungId);

--- a/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userbung/repository/UserBungRepositoryImpl.java
@@ -251,6 +251,24 @@ public class UserBungRepositoryImpl implements UserBungRepository {
     }
 
     @Override
+    @Transactional
+    public boolean confirmParticipation(String userId, String bungId) {
+        long updated = queryFactory
+            .update(userBungEntity)
+            .set(userBungEntity.participationStatus, true)
+            .where(
+                userBungEntity.userEntity.userId.eq(userId),
+                userBungEntity.bungEntity.bungId.eq(bungId),
+                userBungEntity.participationStatus.isFalse()
+            )
+            .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+        return updated > 0;
+    }
+
+    @Override
     public void removeUserFromBung(UserBung userBung) {
         userBungJpaRepository.delete(userBung.toEntity());
     }

--- a/src/main/java/io/openur/domain/userbung/service/UserBungService.java
+++ b/src/main/java/io/openur/domain/userbung/service/UserBungService.java
@@ -1,5 +1,7 @@
 package io.openur.domain.userbung.service;
 
+import io.openur.domain.challenge.enums.ChallengeActivityType;
+import io.openur.domain.challenge.event.ChallengeEventsPublisher;
 import io.openur.domain.userbung.exception.RemoveUserFromBungException;
 import io.openur.domain.userbung.model.UserBung;
 import io.openur.domain.userbung.repository.UserBungRepositoryImpl;
@@ -17,6 +19,7 @@ public class UserBungService {
 
     private final UserBungRepositoryImpl userBungRepository;
     private final MethodSecurityService methodSecurityService;
+    private final ChallengeEventsPublisher challengeEventsPublisher;
 
     @Transactional
     @PreAuthorize("@methodSecurityService.isOwnerOfBung(#userDetails, #bungId)")
@@ -51,8 +54,13 @@ public class UserBungService {
     @Transactional
     @PreAuthorize("@methodSecurityService.isBungParticipant(#userDetails, #bungId)")
     public void confirmBungParticipation(UserDetailsImpl userDetails, String bungId) {
-        UserBung userBung = userBungRepository.findByUserIdAndBungId(userDetails.getUser().getUserId(), bungId);
-        userBung.setParticipationStatus(true);
-        userBungRepository.save(userBung);
+        boolean confirmed = userBungRepository.confirmParticipation(
+            userDetails.getUser().getUserId(), bungId);
+        if (!confirmed) {
+            return;
+        }
+
+        challengeEventsPublisher.publishChallengeCheck(
+            userDetails.getUser().getUserId(), ChallengeActivityType.BUNG_CERTIFY);
     }
 }

--- a/src/main/java/io/openur/domain/userchallenge/model/UserChallenge.java
+++ b/src/main/java/io/openur/domain/userchallenge/model/UserChallenge.java
@@ -30,7 +30,9 @@ public class UserChallenge {
         this.challengeStage = nextStage;
         this.completedDate = null;
         this.nftCompleted = false;
-        this.currentCount = prevChallenge.getCurrentCount();
+        // 단계 조건은 누적 회수 기준. prevChallenge는 완료 직전에 조회된 스냅샷이라
+        // 완료 처리에서 더해진 +1이 빠져 있으므로 여기서 보정해 승계한다.
+        this.currentCount = prevChallenge.getCurrentCount() + 1;
         this.currentProgress = (float) this.currentCount / nextStage.getConditionAsCount();
     }
 

--- a/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepository.java
+++ b/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepository.java
@@ -5,6 +5,7 @@ import io.openur.domain.userchallenge.model.UserChallenge;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,7 @@ public interface UserChallengeRepository {
 
     void markNftCompleted(Long userChallengeId);
 
-    boolean existsByUserId(String userId);
+    Set<Long> findChallengeIdsByUserId(String userId);
 
     Page<ChallengeRow> findUncompletedChallengesByUserId(
         String userId, Pageable pageable
@@ -52,9 +53,7 @@ public interface UserChallengeRepository {
         String userId, Long challengeId
     );
 
-    Optional<UserChallenge> findFirstBySimpleRepetitiveChallenge(String userId);
-
-    List<UserChallenge> findAllBySimpleRepetitiveChallenge(String userId);
+    List<UserChallenge> findAllUncompletedByChallengeIds(String userId, List<Long> challengeIds);
 
     void delete(UserChallenge userChallenge);
 }

--- a/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepositoryImpl.java
+++ b/src/main/java/io/openur/domain/userchallenge/repository/UserChallengeRepositoryImpl.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -98,7 +99,11 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
             .set(userChallengeEntity.currentCount, userChallengeEntity.currentCount.add(1))
             .set(userChallengeEntity.completedDate, LocalDateTime.now())
             .set(userChallengeEntity.nftCompleted, false)
-            .where(userChallengeEntity.userChallengeId.in(userChallengeIds))
+            .where(
+                userChallengeEntity.userChallengeId.in(userChallengeIds),
+                // 동시 요청이 같은 행을 중복 완료 처리하지 않도록 멱등 가드
+                userChallengeEntity.completedDate.isNull()
+            )
             .execute();
 
         entityManager.flush();
@@ -121,13 +126,14 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
     }
 
     @Override
-    public boolean existsByUserId(String userId) {
-        Integer one = queryFactory
-            .selectOne()
+    public Set<Long> findChallengeIdsByUserId(String userId) {
+        return Set.copyOf(queryFactory
+            .selectDistinct(challengeEntity.challengeId)
             .from(userChallengeEntity)
+            .join(userChallengeEntity.challengeStageEntity, challengeStageEntity)
+            .join(challengeStageEntity.challengeEntity, challengeEntity)
             .where(userChallengeEntity.userEntity.userId.eq(userId))
-            .fetchFirst();
-        return one != null;
+            .fetch());
     }
 
     @Override
@@ -318,26 +324,9 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
     }
 
     @Override
-    public Optional<UserChallenge> findFirstBySimpleRepetitiveChallenge(String userId
+    public List<UserChallenge> findAllUncompletedByChallengeIds(
+        String userId, List<Long> challengeIds
     ) {
-        return Optional.ofNullable(
-            queryFactory
-                .selectFrom(userChallengeEntity)
-                .join(userChallengeEntity.challengeStageEntity, challengeStageEntity)
-                .join(challengeStageEntity.challengeEntity, challengeEntity)
-                .where(
-                    userChallengeEntity.userEntity.userId.eq(userId),
-                    userChallengeEntity.completedDate.isNull(),
-                    challengeEntity.conditionAsDate.isNull(),
-                    challengeEntity.conditionAsText.isNull()
-                )
-                .orderBy(challengeStageEntity.stageNumber.asc())
-                .fetchFirst()
-        ).map(UserChallenge::from);
-    }
-
-    @Override
-    public List<UserChallenge> findAllBySimpleRepetitiveChallenge(String userId) {
         return queryFactory
             .selectFrom(userChallengeEntity)
             .join(userChallengeEntity.challengeStageEntity, challengeStageEntity)
@@ -345,8 +334,7 @@ public class UserChallengeRepositoryImpl implements UserChallengeRepository {
             .where(
                 userChallengeEntity.userEntity.userId.eq(userId),
                 userChallengeEntity.completedDate.isNull(),
-                challengeEntity.conditionAsDate.isNull(),
-                challengeEntity.conditionAsText.isNull()
+                challengeEntity.challengeId.in(challengeIds)
             )
             .orderBy(challengeStageEntity.stageNumber.asc())
             .fetch()

--- a/src/main/java/io/openur/domain/userchallenge/service/UserChallengeInitializer.java
+++ b/src/main/java/io/openur/domain/userchallenge/service/UserChallengeInitializer.java
@@ -1,6 +1,7 @@
 package io.openur.domain.userchallenge.service;
 
 import io.openur.domain.challenge.model.ChallengeStage;
+import io.openur.domain.challenge.repository.ChallengeJpaRepository;
 import io.openur.domain.challenge.repository.ChallengeStageRepository;
 import io.openur.domain.user.model.User;
 import io.openur.domain.user.repository.UserRepository;
@@ -9,6 +10,7 @@ import io.openur.domain.userchallenge.repository.UserChallengeRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,13 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
  * 별도 컴포넌트로 분리한 이유:
  * Self-invocation 회피 — 같은 빈 안에서 호출해도 Spring AOP가 트랜잭션을 적용하도록.
  *
+ * 진행 기록이 이미 있는 유저도 "아직 row가 없는 challenge"의 최소 단계를 차집합으로
+ * 발급한다. (운영 중 challenge가 추가돼도 기존 유저에게 발급되도록)
+ *
  * 동시성 주의: 같은 userId에 대한 두 호출이 동시에 도달하면 양쪽 모두
- * existsByUserId == false를 보고 INSERT를 시도해 row가 중복될 수 있음.
+ * 같은 차집합을 보고 INSERT를 시도해 row가 중복될 수 있음.
  * 후속 PR에서 tb_users_challenges에 (user_id, challenge_stage_id) UNIQUE 제약을
  * 추가하고 DataIntegrityViolationException을 graceful하게 처리하는 것을 권장.
  *
-     * 트랜잭션 propagation: REQUIRED를 사용하여 호출자(예: BungService.completeBung)와
-     * 같은 트랜잭션 안에서 동작한다.
+ * 트랜잭션 propagation: REQUIRED를 사용하여 호출자(예: BungService.completeBung)와
+ * 같은 트랜잭션 안에서 동작한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -37,11 +42,14 @@ public class UserChallengeInitializer {
 
     private final UserChallengeRepository userChallengeRepository;
     private final ChallengeStageRepository stageRepository;
+    private final ChallengeJpaRepository challengeJpaRepository;
     private final UserRepository userRepository;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void ensureInitialized(String userId) {
-        if (userChallengeRepository.existsByUserId(userId)) {
+        Set<Long> existingChallengeIds =
+            userChallengeRepository.findChallengeIdsByUserId(userId);
+        if (existingChallengeIds.size() == challengeJpaRepository.count()) {
             return;
         }
 
@@ -58,9 +66,11 @@ public class UserChallengeInitializer {
 
         do {
             challengeStages = stageRepository.findAllByMinimumStages(pageable);
-            challengeStages.forEach(stage ->
-                newUserChallenges.add(new UserChallenge(user, stage))
-            );
+            challengeStages.forEach(stage -> {
+                if (!existingChallengeIds.contains(stage.getChallengeId())) {
+                    newUserChallenges.add(new UserChallenge(user, stage));
+                }
+            });
             pageable = pageable.next();
         } while (challengeStages.hasNext());
 

--- a/src/test/java/io/openur/controller/AdminChallengeApiTest.java
+++ b/src/test/java/io/openur/controller/AdminChallengeApiTest.java
@@ -27,7 +27,8 @@ public class AdminChallengeApiTest extends TestSupport {
                 .header(AUTH_HEADER, getTestUserToken1()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.message").value("Admin challenges fetched successfully"))
-            .andExpect(jsonPath("$.data", hasSize(2)))
+            // 시드 도전과제: 1, 2, 3, 4, 5, 6, 7, 19 (challengeId asc)
+            .andExpect(jsonPath("$.data", hasSize(8)))
             .andExpect(jsonPath("$.data[0].challengeId").value(1))
             .andExpect(jsonPath("$.data[0].name").value("test_challenge"))
             .andExpect(jsonPath("$.data[0].assignedUserChallengeCount").value(1))
@@ -36,6 +37,7 @@ public class AdminChallengeApiTest extends TestSupport {
             .andExpect(jsonPath("$.data[0].stages[0].stageId").value(1))
             .andExpect(jsonPath("$.data[0].stages[0].assignedUserChallengeCount").value(1))
             .andExpect(jsonPath("$.data[0].stages[0].removable").value(false))
+            .andExpect(jsonPath("$.data[1].challengeId").value(2))
             .andExpect(jsonPath("$.data[1].stages", hasSize(3)));
     }
 

--- a/src/test/java/io/openur/controller/BungApiTest.java
+++ b/src/test/java/io/openur/controller/BungApiTest.java
@@ -28,6 +28,8 @@ import io.openur.domain.bunghashtag.repository.BungHashtagRepository;
 import io.openur.domain.hashtag.model.Hashtag;
 import io.openur.domain.hashtag.repository.HashtagRepository;
 import io.openur.domain.userbung.repository.UserBungJpaRepository;
+import io.openur.domain.userchallenge.entity.UserChallengeEntity;
+import io.openur.domain.userchallenge.repository.UserChallengeJpaRepository;
 import io.openur.global.dto.PagedResponse;
 import io.openur.global.dto.Response;
 import io.openur.global.dto.ExceptionDto;
@@ -60,7 +62,9 @@ public class BungApiTest extends TestSupport {
     protected BungHashtagRepository bungHashtagRepository;
     @Autowired
     private BungRepository bungRepository;
-    
+    @Autowired
+    private UserChallengeJpaRepository userChallengeJpaRepository;
+
     @Test
     @DisplayName("벙 생성")
     @Transactional
@@ -101,6 +105,211 @@ public class BungApiTest extends TestSupport {
         assert hashtagRepository.findByHashtagStrIn(hashtags).stream().map(Hashtag::getHashtagStr)
             .toList().containsAll(hashtags);
         assert bungEntity.getMainImage().equals("image1.jpg");
+    }
+
+    @Test
+    @DisplayName("벙 생성 시 벙 생성 도전과제만 카운트된다")
+    @Transactional
+    void createBung_countsCreateChallenges() throws Exception {
+        // user2: 도전과제 진행 기록이 없는 유저 (lazy 초기화부터 트리거까지 전체 경로 검증)
+        String token = getTestUserToken2();
+        String userId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+
+        createBung(token, "도전과제 트리거 벙");
+
+        List<UserChallengeEntity> rows = findUserChallenges(userId);
+
+        // 벙 생성 매핑 과제 2번(repetitive): 1단계(조건 1) 완료 + 2단계 발급, 누적 1 승계
+        UserChallengeEntity challenge2Stage1 = findRow(rows, 2L, 1);
+        assertThat(challenge2Stage1.getCompletedDate()).isNotNull();
+        assertThat(challenge2Stage1.getCurrentCount()).isEqualTo(1);
+
+        UserChallengeEntity challenge2Stage2 = findRow(rows, 2L, 2);
+        assertThat(challenge2Stage2.getCompletedDate()).isNull();
+        assertThat(challenge2Stage2.getCurrentCount()).isEqualTo(1);
+
+        // 벙 생성 매핑 과제 6번(normal, 조건 1회): 첫 생성으로 완료
+        UserChallengeEntity challenge6 = findRow(rows, 6L, 1);
+        assertThat(challenge6.getCompletedDate()).isNotNull();
+        assertThat(challenge6.getCurrentCount()).isEqualTo(1);
+
+        // 벙 생성과 무관한 과제(1번)는 초기화만 되고 카운트되지 않는다
+        UserChallengeEntity unrelated = findRow(rows, 1L, 1);
+        assertThat(unrelated.getCompletedDate()).isNull();
+        assertThat(unrelated.getCurrentCount()).isZero();
+
+        // 2번째 생성: 2단계(누적 3회 조건) 미달이므로 카운트만 오른다 (raise 경로)
+        createBung(token, "도전과제 트리거 벙 2");
+
+        UserChallengeEntity stage2After = findRow(findUserChallenges(userId), 2L, 2);
+        assertThat(stage2After.getCompletedDate()).isNull();
+        assertThat(stage2After.getCurrentCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("진행 기록이 있는 기존 유저에게도 새 도전과제가 차집합 발급되고 트리거가 동작한다")
+    @Transactional
+    void createBung_issuesNewChallengesToExistingUser() throws Exception {
+        // user1: 시드에 과제 1, 2 진행 기록이 이미 있는 유저
+        String token = getTestUserToken1();
+        String userId = "9e1bfc60-f76a-47dc-9147-803653707192";
+
+        createBung(token, "기존 유저 차집합 발급 벙");
+
+        List<UserChallengeEntity> rows = findUserChallenges(userId);
+
+        // 기록이 없던 과제 6은 새로 발급되고, 벙 생성 트리거로 즉시 완료된다
+        UserChallengeEntity challenge6 = findRow(rows, 6L, 1);
+        assertThat(challenge6.getCompletedDate()).isNotNull();
+        assertThat(challenge6.getCurrentCount()).isEqualTo(1);
+
+        // 이미 row가 있는 과제 2는 차집합 발급 대상이 아니다 (기존 완료 row 1개 그대로)
+        List<UserChallengeEntity> challenge2Rows = rows.stream()
+            .filter(uc -> uc.getChallengeStageEntity().getChallengeEntity()
+                .getChallengeId().equals(2L))
+            .toList();
+        assertThat(challenge2Rows).hasSize(1);
+        assertThat(challenge2Rows.get(0).getCompletedDate()).isNotNull();
+
+        // 벙 생성과 무관한 신규 과제(3번)는 발급만 되고 카운트되지 않는다
+        UserChallengeEntity challenge3 = findRow(rows, 3L, 1);
+        assertThat(challenge3.getCompletedDate()).isNull();
+        assertThat(challenge3.getCurrentCount()).isZero();
+    }
+
+    private void createBung(String token, String name) throws Exception {
+        var submittedBung = new HashMap<>();
+        submittedBung.put("name", name);
+        submittedBung.put("description", "설명");
+        submittedBung.put("location", "장소");
+        submittedBung.put("startDateTime", LocalDateTime.now().plusDays(3).toString());
+        submittedBung.put("endDateTime", LocalDateTime.now().plusDays(4).toString());
+        submittedBung.put("distance", "5.0");
+        submittedBung.put("pace", "6'00\"");
+        submittedBung.put("memberNumber", 5);
+        submittedBung.put("hasAfterRun", false);
+        submittedBung.put("afterRunDescription", "");
+        submittedBung.put("hashtags", List.of());
+        submittedBung.put("mainImage", "image1.jpg");
+
+        mockMvc.perform(
+            post(PREFIX)
+                .header(AUTH_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(submittedBung))
+        ).andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("벙 참여 시 벙 참여 도전과제만 카운트된다")
+    @Transactional
+    void joinBung_countsJoinChallenges() throws Exception {
+        // user2가 user3 소유의 미시작 벙에 참여한다
+        String token = getTestUserToken2();
+        String userId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+        String bungId = "90477004-1422-4551-acce-04584b34612e";
+
+        mockMvc.perform(
+            get(PREFIX + "/{bungId}/join", bungId)
+                .header(AUTH_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        List<UserChallengeEntity> rows = findUserChallenges(userId);
+
+        // 벙 참여 매핑 과제 3번(repetitive): 1단계(조건 1) 완료 + 2단계 발급, 누적 1 승계
+        UserChallengeEntity challenge3Stage1 = findRow(rows, 3L, 1);
+        assertThat(challenge3Stage1.getCompletedDate()).isNotNull();
+        assertThat(challenge3Stage1.getCurrentCount()).isEqualTo(1);
+
+        UserChallengeEntity challenge3Stage2 = findRow(rows, 3L, 2);
+        assertThat(challenge3Stage2.getCompletedDate()).isNull();
+        assertThat(challenge3Stage2.getCurrentCount()).isEqualTo(1);
+
+        // 벙 참여 매핑 과제 5번(normal, 조건 1회): 첫 참여로 완료
+        UserChallengeEntity challenge5 = findRow(rows, 5L, 1);
+        assertThat(challenge5.getCompletedDate()).isNotNull();
+        assertThat(challenge5.getCurrentCount()).isEqualTo(1);
+
+        // 벙 생성 매핑 과제(2번, 6번)는 참여로는 오르지 않는다
+        UserChallengeEntity challenge2 = findRow(rows, 2L, 1);
+        assertThat(challenge2.getCompletedDate()).isNull();
+        assertThat(challenge2.getCurrentCount()).isZero();
+
+        UserChallengeEntity challenge6 = findRow(rows, 6L, 1);
+        assertThat(challenge6.getCompletedDate()).isNull();
+        assertThat(challenge6.getCurrentCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("완주 과제는 벙주는 완료 시점, 벙원은 피드백 제출 시점에 카운트된다")
+    @Transactional
+    void completeBung_countsOwnerThenMemberOnFeedback() throws Exception {
+        // 시드: user2(벙주), user3(벙원)
+        String bungId = "b1234567-89ab-cdef-0123-456789abcdef";
+        String ownerUserId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+        String memberUserId = "5d22bd65-f1ed-4e7b-bc7b-0a59580d3176";
+
+        mockMvc.perform(
+            patch(PREFIX + "/{bungId}/complete", bungId)
+                .header(AUTH_HEADER, getTestUserToken2())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+
+        // 벙주: 완료 즉시 19번 1단계 완료 + 2단계 승계(누적 1), 7번 완료
+        List<UserChallengeEntity> ownerRows = findUserChallenges(ownerUserId);
+        assertThat(findRow(ownerRows, 19L, 1).getCompletedDate()).isNotNull();
+        assertThat(findRow(ownerRows, 19L, 2).getCurrentCount()).isEqualTo(1);
+        assertThat(findRow(ownerRows, 7L, 1).getCompletedDate()).isNotNull();
+
+        // 벙원: 완료 시점에는 아직 카운트되지 않는다 (진행표 발급 전)
+        assertThat(findUserChallenges(memberUserId)).isEmpty();
+
+        // 벙원이 피드백 제출 → 완주 과제 카운트
+        submitFeedback(getTestUserToken3(), bungId);
+        List<UserChallengeEntity> memberRows = findUserChallenges(memberUserId);
+        assertThat(findRow(memberRows, 19L, 1).getCompletedDate()).isNotNull();
+        assertThat(findRow(memberRows, 19L, 2).getCurrentCount()).isEqualTo(1);
+        assertThat(findRow(memberRows, 7L, 1).getCompletedDate()).isNotNull();
+
+        // 벙원 피드백 재제출은 무시된다
+        submitFeedback(getTestUserToken3(), bungId);
+        assertThat(findRow(findUserChallenges(memberUserId), 19L, 2).getCurrentCount())
+            .isEqualTo(1);
+
+        // 벙주는 피드백을 제출해도 다시 카운트되지 않는다
+        submitFeedback(getTestUserToken2(), bungId);
+        assertThat(findRow(findUserChallenges(ownerUserId), 19L, 2).getCurrentCount())
+            .isEqualTo(1);
+    }
+
+    private void submitFeedback(String token, String bungId) throws Exception {
+        var feedbackRequest = new HashMap<>();
+        feedbackRequest.put("bungId", bungId);
+        feedbackRequest.put("targetUserIds", List.of());
+
+        mockMvc.perform(
+            patch("/v1/users/feedback")
+                .header(AUTH_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonify(feedbackRequest))
+        ).andExpect(status().isOk());
+    }
+
+    private List<UserChallengeEntity> findUserChallenges(String userId) {
+        return userChallengeJpaRepository.findAll().stream()
+            .filter(uc -> uc.getUserEntity().getUserId().equals(userId))
+            .toList();
+    }
+
+    private UserChallengeEntity findRow(
+        List<UserChallengeEntity> rows, Long challengeId, int stageNumber
+    ) {
+        return rows.stream()
+            .filter(uc -> uc.getChallengeStageEntity().getChallengeEntity()
+                .getChallengeId().equals(challengeId))
+            .filter(uc -> uc.getChallengeStageEntity().getStageNumber() == stageNumber)
+            .findFirst().orElseThrow();
     }
 
     @Nested

--- a/src/test/java/io/openur/controller/ChallengeApiTest.java
+++ b/src/test/java/io/openur/controller/ChallengeApiTest.java
@@ -56,7 +56,11 @@ public class ChallengeApiTest extends TestSupport {
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).hasSize(1);
+            // 시드 normal challenge: 1, 5, 6, 7. 보상 수령 가능(1)이 최우선 정렬된다.
+            assertThat(response.getData()).hasSize(4);
+            assertThat(response.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(1L, 5L, 6L, 7L);
             GeneralChallengeDto first = response.getData().get(0);
             assertThat(first.getChallengeId()).isEqualTo(1L);
             assertThat(first.getUserChallengeId()).isEqualTo(1L);
@@ -109,14 +113,17 @@ public class ChallengeApiTest extends TestSupport {
                     .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk()).andReturn();
 
-            // then: tb_challenges에 normal 1개(challenge_id=1, stage 1)가 있으므로 1건
+            // then: tb_challenges에 normal 4개(challenge_id=1, 5, 6, 7)가 있으므로 4건
             PagedResponse<GeneralChallengeDto> response = parseResponse(
                 result.getResponse().getContentAsString(),
                 new TypeReference<>() {}
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).hasSize(1);
+            assertThat(response.getData()).hasSize(4);
+            assertThat(response.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(1L, 5L, 6L, 7L);
             GeneralChallengeDto first = response.getData().get(0);
             assertThat(first.getChallengeId()).isEqualTo(1L);
             assertThat(first.getStageCount()).isEqualTo(1);
@@ -141,14 +148,17 @@ public class ChallengeApiTest extends TestSupport {
                     .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk()).andReturn();
 
-            // then: tb_challenges에 repetitive 1개(challenge_id=2)이고 stage 1이 노출
+            // then: tb_challenges에 repetitive 4개(challenge_id=2, 3, 4, 19)이고 각 stage 1이 노출
             PagedResponse<GeneralChallengeDto> response = parseResponse(
                 result.getResponse().getContentAsString(),
                 new TypeReference<>() {}
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).hasSize(1);
+            assertThat(response.getData()).hasSize(4);
+            assertThat(response.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(2L, 3L, 4L, 19L);
             GeneralChallengeDto first = response.getData().get(0);
             assertThat(first.getChallengeId()).isEqualTo(2L);
             assertThat(first.getStageCount()).isEqualTo(1); // 최소 stage_number는 1
@@ -214,7 +224,11 @@ public class ChallengeApiTest extends TestSupport {
             );
 
             assertNotNull(response);
-            assertThat(response.getData()).hasSize(1);
+            // 시드 repetitive challenge: 2, 3, 4, 19. 보상 수령 가능(2)이 최우선 정렬된다.
+            assertThat(response.getData()).hasSize(4);
+            assertThat(response.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(2L, 3L, 4L, 19L);
             GeneralChallengeDto first = response.getData().get(0);
             assertThat(first.getChallengeId()).isEqualTo(2L);
             assertThat(first.getUserChallengeId()).isEqualTo(2L);
@@ -258,8 +272,14 @@ public class ChallengeApiTest extends TestSupport {
                 new TypeReference<>() {}
             );
 
-            assertThat(generalResponse.getData()).isEmpty();
-            assertThat(repetitiveResponse.getData()).isEmpty();
+            // NFT 보상까지 완료한 challenge 1(normal), 2(repetitive)는 목록에서 빠지고
+            // 나머지 시드 도전과제만 남는다.
+            assertThat(generalResponse.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(5L, 6L, 7L);
+            assertThat(repetitiveResponse.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(3L, 4L, 19L);
         }
 
         @Test
@@ -293,7 +313,12 @@ public class ChallengeApiTest extends TestSupport {
                 new TypeReference<>() {}
             );
 
-            assertThat(response.getData()).hasSize(1);
+            // 시드 repetitive challenge 4개 중 challenge 2는 보상 수령 가능 stage 2가
+            // 진행 중 stage 3(60%)보다 우선 노출된다.
+            assertThat(response.getData()).hasSize(4);
+            assertThat(response.getData())
+                .extracting(GeneralChallengeDto::getChallengeId)
+                .containsExactly(2L, 3L, 4L, 19L);
             GeneralChallengeDto first = response.getData().get(0);
             assertThat(first.getChallengeId()).isEqualTo(2L);
             assertThat(first.getUserChallengeId()).isEqualTo(2L);

--- a/src/test/java/io/openur/controller/UserBungApiTest.java
+++ b/src/test/java/io/openur/controller/UserBungApiTest.java
@@ -10,7 +10,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.openur.config.TestSupport;
 import io.openur.domain.userbung.model.UserBung;
 import io.openur.domain.userbung.repository.UserBungRepositoryImpl;
+import io.openur.domain.userchallenge.entity.UserChallengeEntity;
+import io.openur.domain.userchallenge.repository.UserChallengeJpaRepository;
 import io.openur.global.dto.ExceptionDto;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +30,8 @@ public class UserBungApiTest extends TestSupport {
     private static final String PREFIX = "/v1/bungs";
     @Autowired
     protected UserBungRepositoryImpl userBungRepository;
+    @Autowired
+    private UserChallengeJpaRepository userChallengeJpaRepository;
 
     @Nested
     @DisplayName("멤버 제거")
@@ -231,6 +236,50 @@ public class UserBungApiTest extends TestSupport {
             String bungId = "c0477004-1632-455f-acc9-04584b55921f";
 
             isOkTest(token, userId, bungId);
+        }
+
+        @Test
+        @DisplayName("200 Ok. 참여 인증 시 인증 도전과제가 오르고 재호출해도 중복 카운트되지 않는다")
+        void confirmParticipation_countsCertifyOnce() throws Exception {
+            // user2: participation_status=false 참가자
+            String token = getTestUserToken2();
+            String userId = "91b4928f-8288-44dc-a04d-640911f0b2be";
+            String bungId = "c0477004-1632-455f-acc9-04584b55921f";
+
+            mockMvc.perform(
+                patch(PREFIX + "/{bungId}/participated", bungId)
+                    .header(AUTH_HEADER, token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            // 참여 인증 매핑 과제 4번(repetitive): 1단계(조건 1) 완료 + 2단계 발급, 누적 1 승계
+            UserChallengeEntity stage1 = findCertifyChallengeRow(userId, 1);
+            assertThat(stage1.getCompletedDate()).isNotNull();
+            assertThat(stage1.getCurrentCount()).isEqualTo(1);
+
+            UserChallengeEntity stage2 = findCertifyChallengeRow(userId, 2);
+            assertThat(stage2.getCompletedDate()).isNull();
+            assertThat(stage2.getCurrentCount()).isEqualTo(1);
+
+            // 이미 인증된 상태에서 같은 API를 재호출하면 카운트가 그대로다 (중복 방지 가드)
+            mockMvc.perform(
+                patch(PREFIX + "/{bungId}/participated", bungId)
+                    .header(AUTH_HEADER, token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            UserChallengeEntity stage2After = findCertifyChallengeRow(userId, 2);
+            assertThat(stage2After.getCompletedDate()).isNull();
+            assertThat(stage2After.getCurrentCount()).isEqualTo(1);
+        }
+
+        private UserChallengeEntity findCertifyChallengeRow(String userId, int stageNumber) {
+            return userChallengeJpaRepository.findAll().stream()
+                .filter(uc -> uc.getUserEntity().getUserId().equals(userId))
+                .filter(uc -> uc.getChallengeStageEntity().getChallengeEntity()
+                    .getChallengeId().equals(4L))
+                .filter(uc -> uc.getChallengeStageEntity().getStageNumber() == stageNumber)
+                .findFirst().orElseThrow();
         }
 
         @Test

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -23,7 +23,10 @@ VALUES ('c0477004-1632-455f-acc9-04584b55921f', 'test1_bung', 'temp_description'
        ('a1234567-89ab-cdef-0123-456789abcdef', 'past_bung_incompleted', 'past_bung_description', 'New York', 40.7128, -74.0060,
         CURRENT_TIMESTAMP - 2, CURRENT_TIMESTAMP - 1, 5, '7"00', 3, 2, false, null, false, false, 'image3.png'),
        ('a1234567-89ab-cdef-0123-1982ey1kbjas', 'past_bung_completed', 'past_bung_description', 'New York', 40.7128, -74.0060,
-        CURRENT_TIMESTAMP - 4, CURRENT_TIMESTAMP - 3, 5, '7"00', 3, 3, false, null, true, false, 'image4.png')
+        CURRENT_TIMESTAMP - 4, CURRENT_TIMESTAMP - 3, 5, '7"00', 3, 3, false, null, true, false, 'image4.png'),
+       -- 벙 완료 도전과제 트리거 테스트용: 시작됐지만 미완료, user2(벙주, 인증됨) / user3(미인증)
+       ('b1234567-89ab-cdef-0123-456789abcdef', 'trigger_complete_bung', 'challenge_trigger_bung', 'Busan', 35.1796, 129.0756,
+        CURRENT_TIMESTAMP - 2, CURRENT_TIMESTAMP - 1, 5, '7"00', 3, 2, false, null, false, false, 'image5.png')
 ;
 
 INSERT INTO tb_users_bungs (user_bung_id, bung_id, user_id, participation_status, modified_at,
@@ -39,7 +42,11 @@ VALUES (1, 'c0477004-1632-455f-acc9-04584b55921f', '9e1bfc60-f76a-47dc-9147-8036
        (5, 'a1234567-89ab-cdef-0123-456789abcdef', '91b4928f-8288-44dc-a04d-640911f0b2be', false,
         CURRENT_TIMESTAMP(), true),
        (6, 'a1234567-89ab-cdef-0123-1982ey1kbjas', '5d22bd65-f1ed-4e7b-bc7b-0a59580d3176', false,
-        CURRENT_TIMESTAMP(), true)
+        CURRENT_TIMESTAMP(), true),
+       (7, 'b1234567-89ab-cdef-0123-456789abcdef', '91b4928f-8288-44dc-a04d-640911f0b2be', true,
+        CURRENT_TIMESTAMP(), true),
+       (8, 'b1234567-89ab-cdef-0123-456789abcdef', '5d22bd65-f1ed-4e7b-bc7b-0a59580d3176', false,
+        CURRENT_TIMESTAMP(), false)
 ;
 
 INSERT INTO tb_hashtags (hashtag_id, hashtag_str)
@@ -66,7 +73,15 @@ INSERT INTO tb_challenges (challenge_id, name, description, challenge_type,
 )
 VALUES
     (1, 'test_challenge', 'test_challenge_description', 'normal', 'footwear', 'count', null, null),
-    (2, 'test_challenge2', 'test_challenge2_description', 'repetitive', 'footwear', 'count', null, null)
+    (2, 'test_challenge2', 'test_challenge2_description', 'repetitive', 'footwear', 'count', null, null),
+    -- 활동 트리거 매핑(ChallengeActivityType)과 맞춘 시드:
+    -- BUNG_CREATE→[2,6], BUNG_JOIN→[3,5], BUNG_CERTIFY→[4], BUNG_COMPLETE→[19,7]
+    (3, '벙 참여하기', '벙 참여하기 반복 도전과제', 'repetitive', 'footwear', 'count', null, null),
+    (4, '벙 참여 인증하기', '벙 참여 인증하기 반복 도전과제', 'repetitive', 'footwear', 'count', null, null),
+    (5, '첫 걸음', '첫 벙 참여 도전과제', 'normal', 'footwear', 'count', null, null),
+    (6, '러너의 시작', '첫 벙 생성 도전과제', 'normal', 'footwear', 'count', null, null),
+    (7, '완주왕', '첫 벙 완주 도전과제', 'normal', 'footwear', 'count', null, null),
+    (19, '벙 완료하기', '벙 완료하기 반복 도전과제', 'repetitive', 'footwear', 'count', null, null)
 ;
 
 INSERT INTO tb_challenge_stages (stage_id, stage_number, condition_count, challenge_id, weight_common, weight_rare, weight_epic)
@@ -74,7 +89,18 @@ VALUES
     (1, 1, 1, 1, 100, 0, 0),
     (2, 1, 1, 2, 100, 0, 0),
     (3, 2, 3, 2, 100, 0, 0),
-    (4, 3, 5, 2, 100, 0, 0)
+    (4, 3, 5, 2, 100, 0, 0),
+    -- stage_id 10+ : 기존 1~4와 충돌 방지
+    (10, 1, 1, 3, 100, 0, 0),
+    (11, 2, 2, 3, 100, 0, 0),
+    (12, 3, 3, 3, 100, 0, 0),
+    (13, 1, 1, 4, 100, 0, 0),
+    (14, 2, 2, 4, 100, 0, 0),
+    (15, 1, 1, 5, 100, 0, 0),
+    (16, 1, 1, 6, 100, 0, 0),
+    (17, 1, 1, 7, 100, 0, 0),
+    (18, 1, 1, 19, 100, 0, 0),
+    (19, 2, 2, 19, 100, 0, 0)
 ;
 
 INSERT INTO tb_users_challenges (user_challenge_id, user_id, challenge_stage_id, current_count, current_progress, nft_completed, completed_date)


### PR DESCRIPTION
## 배경

도전과제 진행 엔진(OnRaise/OnEvolution)은 완성돼 있었지만 트리거가 벙 완료 한 곳뿐이었고, 그마저 활동 구분 없이 모든 count형 과제를 +1 하는 상태였다. 벙 생성/참여/인증 시점에는 발행 자체가 없어 해당 과제들이 전혀 진행되지 않았다.

## 변경 내용

### 활동별 트리거 연결
- `ChallengeActivityType` enum 신설: 활동 → 대상 과제 ID 매핑
  - `BUNG_CREATE → [2, 6]`, `BUNG_JOIN → [3, 5]`, `BUNG_CERTIFY → [4]`, `BUNG_COMPLETE → [7, 19]`
- `createBung` / `joinBung` / `confirmBungParticipation`에 발행 연결 (각 저장과 같은 트랜잭션)
- 완주 정책: **벙주는 벙 완료 시점, 벙원은 완료된 벙에 첫 피드백 제출 시점** 카운트. 참여 인증 여부는 조건 아님
- 기존 무차별 bulk 발행 경로(`publishBulkChallengeCheck` 등) 제거

### 버그 수정
- 단계 진화 시 누적 카운트 1 손실 (off-by-one) — 반복 과제가 1/2/3/6/9 누적 기준으로 정확히 진행되도록 수정
- 유저 첫 활동 초기화 직후 같은 트랜잭션 재조회 시 NPE (`ChallengeStage.toEntity()`의 challenge 참조 유실)

### 안정성
- 참여 인증을 조건부 UPDATE로 전환 — 동시 요청/재호출 시 중복 카운트 방지
- 완료 처리 UPDATE에 멱등 가드 (`completed_date IS NULL`)
- 초기화를 차집합 발급으로 전환 — 운영 중 과제가 추가돼도 기존 유저에게 발급됨. 전 과제 보유 유저는 쿼리 2개로 조기 반환

## 참고: 과제 스펙 정리 (별도 DB 작업, 이 PR 코드와 병행)

- 과제 9(벙 10회 참여), 10(벙 5개 생성), 8(프로필 완성하기)은 기획에서 제외되어 프로덕션 DB에서 삭제됨
- 반복 과제 4개(2, 3, 4, 19) 단계를 1/2/3/6/9로 재설정, 6번은 "벙 1개 생성"으로 변경

## 테스트

- 테스트 시드에 과제 3, 4, 5, 6, 7, 19 + 단계 추가, 활동별 통합 테스트 5건 추가 (MockMvc로 실제 API 경로 검증)
- `./gradlew test` 114건 6회 연속 통과 (`--rerun-tasks`)
- 별도 리뷰 에이전트 3회 리뷰, Critical/Important 전부 반영

## 후속 과제 (이 PR 범위 아님)

- `(user_id, challenge_stage_id)` UNIQUE 제약 + 진화 INSERT 게이트 (동시 요청 중복 행 방지, DDL 필요)
- 참여→탈퇴→재참여 파밍 방어 (제품 결정 대기)
- `currentProgress` 미갱신 (기존 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)